### PR TITLE
retain incoming events in a bucketed sliding window

### DIFF
--- a/bin/flapjack-nagios-receiver
+++ b/bin/flapjack-nagios-receiver
@@ -51,7 +51,7 @@ def process_input(opts)
         'summary'   => check_output,
         'timestamp' => timestamp,
       }.to_json
-      redis.rpush 'events', event
+      redis.lpush 'events', event
     end
   rescue Redis::CannotConnectError
     puts "Error, unable to to connect to the redis server (#{$!})"

--- a/etc/flapjack_config.yaml.example
+++ b/etc/flapjack_config.yaml.example
@@ -1,26 +1,5 @@
 ---
 
-quickstart:
-  redis:
-    host: 127.0.0.1
-    port: 6379
-    db: 6
-  executive:
-    enabled: yes
-    email_queue: email_notifications
-    notification_log_file: log/flapjack-notification.log
-  gateways:
-    email:
-      enabled: yes
-      queue: email_notifications
-      smtp_config:
-        address: "localhost"
-        domain: 'localhost.localdomain'
-        port: 25
-    web:
-      enabled: yes
-      port: 5080
-
 development:
   pid_file: tmp/pids/flapjack.pid
   log_file: log/flapjack.log
@@ -34,7 +13,11 @@ development:
     email_queue: email_notifications
     sms_queue: sms_notifications
     jabber_queue: jabber_notifications
-    notification_log_file: log/flapjack-notification.log
+    pagerduty_queue: pagerduty_notifications
+    notification_log_file: log/notification.log
+    default_contact_timezone: Australia/Broken_Hill
+    archive_events: true
+    events_archive_maxage: 10800
     logger:
       level: INFO
   gateways:

--- a/lib/flapjack/executive.rb
+++ b/lib/flapjack/executive.rb
@@ -57,6 +57,9 @@ module Flapjack
       end
       @default_contact_timezone = tz
 
+      @archive_events        = @config['archive_events'] || false
+      @events_archive_maxage = @config['events_archive_maxage']
+
       # FIXME: Put loading filters into separate method
       # FIXME: should we make the filters more configurable by the end user?
       options = { :log => opts[:logger], :persistence => @redis }
@@ -100,7 +103,9 @@ module Flapjack
 
       until @should_quit
         @logger.debug("Waiting for event...")
-        event = Flapjack::Data::Event.next(:redis => @redis)
+        event = Flapjack::Data::Event.next(:redis => @redis,
+                                           :archive_events => @archive_events,
+                                           :events_archive_maxage => @events_archive_maxage)
         process_event(event) unless event.nil?
       end
 


### PR DESCRIPTION
If archive_events is set to true in the executive's configuration, then all incoming events will be copied to an archive list before processing. The archive list's key contains a timestamp of the current hour, eg "events_archive:2013041916", and is given an expiry of 3 hours by default (overridable by specifying a number of seconds in events_archive_maxage in the executive's configuration. 
