### PR TITLE
restore red background colour in check list views, fixes #419

### DIFF
--- a/lib/flapjack/gateways/web/views/checks.html.erb
+++ b/lib/flapjack/gateways/web/views/checks.html.erb
@@ -23,7 +23,7 @@
       <%
         row_colour = case status
         when 'critical', 'unknown'
-          'error'
+          'danger'
         when 'ok', 'up'
           'success'
         else
@@ -33,23 +33,23 @@
         check_link = "/check?entity=" << u(entity) << "&amp;check=" << u(check)
 
       %>
-      <tr class="<%= row_colour %>">
+      <tr>
         <% unless row_entity && entity == row_entity %>
           <td rowspan="<%= @states[entity].length %>">
             <a href="<%= entity_link %>"><%= h entity %></a>
           </td>
           <% row_entity = entity %>
         <% end %>
-        <td><a href="<%= check_link %>" title="check detail"><%= h check %></a></td>
-        <td class="<%= status %>">
+        <td class="<%= row_colour %>"><a href="<%= check_link %>" title="check detail"><%= h check %></a></td>
+        <td class="<%= row_colour %>">
           <%= h status.upcase %>
           <% if in_unscheduled_outage%> (Ack'd)<% end %>
           <% if in_scheduled_outage %> (Sched)<% end %>
         </td>
-        <td><%= h summary %></td>
-        <td><%= h changed %></td>
-        <td><%= h updated %></td>
-        <td><%= h notified %></td>
+        <td class="<%= row_colour %>"><%= h summary %></td>
+        <td class="<%= row_colour %>"><%= h changed %></td>
+        <td class="<%= row_colour %>"><%= h updated %></td>
+        <td class="<%= row_colour %>"><%= h notified %></td>
       </tr>
 
     <% end %>


### PR DESCRIPTION
I've removed any colour from the entity column as that was a bit of a lie anyway (just used the status of the first check).

The problem was caused by the upgrade to bootstrap 3 which now uses "danger" instead of "error" for the red colour. 

Addresses #419 

Looks like this:

![screen shot 2014-01-16 at 1 19 46 pm](https://f.cloud.github.com/assets/391439/1927399/e746afa0-7e5a-11e3-85d4-a824828d1b45.png)
