### PR TITLE
Fix background color for failing events for entity page.

### DIFF
--- a/lib/flapjack/gateways/web/views/entity.html.erb
+++ b/lib/flapjack/gateways/web/views/entity.html.erb
@@ -21,7 +21,7 @@
       <%
         row_colour = case status
         when 'critical', 'unknown'
-          'error'
+          'danger'
         when 'ok', 'up'
           'success'
         else


### PR DESCRIPTION
Looks like this one table was missed in https://github.com/flpjck/flapjack/issues/419.
