### PR TITLE
Thin 2.0.0.pre introduces breaking change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
       redis (~> 3.0.6)
       resque (~> 1.23.0)
       sinatra
-      thin
+      thin (~> 1.6.1)
       tzinfo (~> 1.0.1)
       tzinfo-data
 
@@ -103,7 +103,7 @@ GEM
     hiredis (0.4.5)
     http_parser.rb (0.6.0)
     i18n (0.6.9)
-    ice_cube (0.11.1)
+    ice_cube (0.11.3)
     listen (2.4.0)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
@@ -122,7 +122,7 @@ GEM
     nokogiri (1.6.1)
       mini_portile (~> 0.5.0)
     numerizer (0.1.1)
-    oj (2.5.3)
+    oj (2.5.4)
     perftools.rb (2.0.1)
     polyglot (0.3.3)
     pry (0.9.12.4)
@@ -192,7 +192,6 @@ GEM
       polyglot (>= 0.3.1)
     tzinfo (1.0.1)
     tzinfo-data (1.2013.9)
-      tzinfo (>= 1.0.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
     webmock (1.16.1)

--- a/flapjack.gemspec
+++ b/flapjack.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'resque', '~> 1.23.0'
   gem.add_dependency 'sinatra'
   gem.add_dependency 'rack-fiber_pool'
-  gem.add_dependency 'thin'
+  gem.add_dependency 'thin', '~> 1.6.1'
   gem.add_dependency 'mail'
   gem.add_dependency 'blather', '~> 0.8.3'
   gem.add_dependency 'chronic'


### PR DESCRIPTION
When using thin version 2.0.0.pre flapjack fails to start producing the following error.

```
uninitialized constant Thin::Logging
/var/lib/gems/2.1.0/gems/flapjack-0.8.5/lib/flapjack/pikelet.rb:225:in `create'
/var/lib/gems/2.1.0/gems/flapjack-0.8.5/lib/flapjack/pikelet.rb:62:in `block in create'
/var/lib/gems/2.1.0/gems/flapjack-0.8.5/lib/flapjack/pikelet.rb:60:in `each'
/var/lib/gems/2.1.0/gems/flapjack-0.8.5/lib/flapjack/pikelet.rb:60:in `create'
/var/lib/gems/2.1.0/gems/flapjack-0.8.5/lib/flapjack/coordinator.rb:132:in `block in add_pikelets'
/var/lib/gems/2.1.0/gems/flapjack-0.8.5/lib/flapjack/coordinator.rb:131:in `each_pair'
/var/lib/gems/2.1.0/gems/flapjack-0.8.5/lib/flapjack/coordinator.rb:131:in `add_pikelets'
/var/lib/gems/2.1.0/gems/flapjack-0.8.5/lib/flapjack/coordinator.rb:36:in `block in start'
/var/lib/gems/2.1.0/gems/em-synchrony-1.0.3/lib/em-synchrony.rb:38:in `block (2 levels) in synchrony'
```

This is addressed by using the thin gem version 1.6.1 and is set in the flapjack.gemspec file.
