### PR TITLE
Allow site-specific ERB templates for messages.

### DIFF
--- a/etc/flapjack_config.yaml.example
+++ b/etc/flapjack_config.yaml.example
@@ -53,6 +53,14 @@ production:
         #  type:
         #  username:
         #  password:
+      # location of custom alert templates
+      #templates:
+      #  rollup_subject.text: '/etc/flapjack/templates/email/rollup_subject.text.erb'
+      #  alert_subject.text: '/etc/flapjack/templates/email/alert_subject.text.erb'
+      #  rollup.text: '/etc/flapjack/templates/email/rollup.text.erb'
+      #  alert.text: '/etc/flapjack/templates/email/alert.text.erb'
+      #  rollup.html: '/etc/flapjack/templates/email/rollup.html.erb'
+      #  alert.html: '/etc/flapjack/templates/email/alert.html.erb'
     sms:
       enabled: no
       queue: sms_notifications
@@ -62,6 +70,10 @@ production:
       logger:
         level: INFO
         syslog_errors: yes
+      # location of custom alert templates
+      #templates:
+      #  rollup.text: '/etc/flapjack/templates/sms/rollup.text.erb'
+      #  alert.text: '/etc/flapjack/templates/sms/alert.text.erb'
     jabber:
       enabled: no
       queue: jabber_notifications
@@ -76,12 +88,19 @@ production:
       logger:
         level: INFO
         syslog_errors: yes
+      # location of custom alert templates
+      #templates:
+      #  rollup.text: '/etc/flapjack/templates/jabber/rollup.text.erb' 
+      #  alert.text: '/etc/flapjack/templates/jabber/alert.text.erb' 
     pagerduty:
       enabled: no
       queue: pagerduty_notifications
       logger:
         level: INFO
         syslog_errors: yes
+      # location of custom alert templates
+      #templates:
+      #  alert.text: '/etc/flapjack/templates/pagerduty/alert.text.erb' 
     web:
       enabled: yes
       port: 3080
@@ -180,6 +199,14 @@ development:
         #  type:
         #  username:
         #  password:
+      # location of custom alert templates
+      #templates:
+      #  rollup_subject.text: '/etc/flapjack/templates/email/rollup_subject.text.erb'
+      #  alert_subject.text: '/etc/flapjack/templates/email/alert_subject.text.erb'
+      #  rollup.text: '/etc/flapjack/templates/email/rollup.text.erb'
+      #  alert.text: '/etc/flapjack/templates/email/alert.text.erb'
+      #  rollup.html: '/etc/flapjack/templates/email/rollup.html.erb'
+      #  alert.html: '/etc/flapjack/templates/email/alert.html.erb'
     sms:
       enabled: yes
       queue: sms_notifications
@@ -191,6 +218,10 @@ development:
       logger:
         level: INFO
         syslog_errors: yes
+      # location of custom alert templates
+      #templates:
+      #  rollup.text: '/etc/flapjack/templates/sms/rollup.text.erb'
+      #  alert.text: '/etc/flapjack/templates/sms/alert.text.erb'
     jabber:
       enabled: no
       queue: jabber_notifications
@@ -205,12 +236,19 @@ development:
       logger:
         level: INFO
         syslog_errors: yes
+      # location of custom alert templates
+      #templates:
+      #  rollup.text: '/etc/flapjack/templates/jabber/rollup.text.erb' 
+      #  alert.text: '/etc/flapjack/templates/jabber/alert.text.erb' 
     pagerduty:
       enabled: no
       queue: pagerduty_notifications
       logger:
         level: INFO
         syslog_errors: yes
+      # location of custom alert templates
+      #templates:
+      #  alert.text: '/etc/flapjack/templates/pagerduty/alert.text.erb' 
     web:
       enabled: yes
       port: 4080

--- a/lib/flapjack/gateways/email.rb
+++ b/lib/flapjack/gateways/email.rb
@@ -110,13 +110,24 @@ module Flapjack
           message_type = alert.rollup ? 'rollup' : 'alert'
 
           mydir = File.dirname(__FILE__)
-          subject_template_path = @config.has_key?('templates') && @config['templates']["#{message_type}_subject.text"] \
-            || mydir + "/email/#{message_type}_subject.text.erb"
-          text_template_path    = @config.has_key?('templates') && @config['templates']["#{message_type}.text"] \
-            || mydir + "/email/#{message_type}.text.erb"
-          html_template_path    = @config.has_key?('templates') && @config['templates']["#{message_type}.html"] \
-            || mydir + "/email/#{message_type}.html.erb"
-
+          subject_template_path = case
+          when @config.has_key?('templates') && @config['templates']["#{message_type}_subject.text"]
+            @config['templates']["#{message_type}_subject.text"]
+          else
+            mydir + "/email/#{message_type}_subject.text.erb"
+          end
+          text_template_path = case
+          when @config.has_key?('templates') && @config['templates']["#{message_type}.text"]
+            @config['templates']["#{message_type}.text"]
+          else
+            mydir + "/email/#{message_type}.text.erb"
+          end
+          html_template_path = case
+          when @config.has_key?('templates') && @config['templates']["#{message_type}.html"]
+            @config['templates']["#{message_type}.html"]
+          else
+            mydir + "/email/#{message_type}.html.erb"
+          end
           subject_template = ERB.new(File.read(subject_template_path), nil, '-')
           text_template    = ERB.new(File.read(text_template_path), nil, '-')
           html_template    = ERB.new(File.read(html_template_path), nil, '-')

--- a/lib/flapjack/gateways/jabber.rb
+++ b/lib/flapjack/gateways/jabber.rb
@@ -533,8 +533,12 @@ module Flapjack
             message_type = alert.rollup ? 'rollup' : 'alert'
 
             mydir = File.dirname(__FILE__)
-            message_template_path = @config.has_key?('templates') && @config['templates']["#{message_type}.text"] \
-              || mydir + "/jabber/#{message_type}.text.erb"
+            message_template_path = case
+            when @config.has_key?('templates') && @config['templates']["#{message_type}.text"]
+              @config['templates']["#{message_type}.text"]
+            else
+              mydir + "/jabber/#{message_type}.text.erb"
+            end
             message_template = ERB.new(File.read(message_template_path), nil, '-')
 
             @alert = alert

--- a/lib/flapjack/gateways/pagerduty.rb
+++ b/lib/flapjack/gateways/pagerduty.rb
@@ -81,8 +81,12 @@ module Flapjack
                           "check: '#{alert.check}', state: #{alert.state}, summary: #{alert.summary}")
 
             mydir = File.dirname(__FILE__)
-            message_template_path = @config.has_key?('templates') && @config['templates']['alert.text'] \
-              || mydir + "/pagerduty/alert.text.erb"
+            message_template_path = case
+            when @config.has_key?('templates') && @config['templates']['alert.text']
+              @config['templates']['alert.text']
+            else
+              mydir + "/pagerduty/alert.text.erb"
+            end
             message_template = ERB.new(File.read(message_template_path), nil, '-')
 
             @alert = alert

--- a/lib/flapjack/gateways/sms_messagenet.rb
+++ b/lib/flapjack/gateways/sms_messagenet.rb
@@ -34,8 +34,12 @@ module Flapjack
           message_type    = alert.rollup ? 'rollup' : 'alert'
 
           my_dir = File.dirname(__FILE__)
-          sms_template_path = @config.has_key?('templates') && @config['templates']["#{message_type}.text"] \
-            || my_dir + "/sms_messagenet/#{message_type}.text.erb"
+          sms_template_path = case
+          when @config.has_key?('templates') && @config['templates']["#{message_type}.text"]
+            @config['templates']["#{message_type}.text"]
+          else
+            my_dir + "/sms_messagenet/#{message_type}.text.erb"
+          end
           sms_template = ERB.new(File.read(sms_template_path), nil, '-')
 
           @alert  = alert


### PR DESCRIPTION
Allows the location of the alert templates to be overridable via the config. Finishes up https://github.com/flpjck/flapjack/issues/112.
