### PR TITLE
Allow contacts to be associated with a common entity "ALL"

### DIFF
--- a/lib/flapjack/data/entity.rb
+++ b/lib/flapjack/data/entity.rb
@@ -32,7 +32,7 @@ module Flapjack
         raise "Redis connection not set" unless redis = options[:redis]
         raise "Entity name not provided" unless entity['name'] && !entity['name'].empty?
 
-        #FIXME: should probably raise an exception if trying to create a new entity with the 
+        #FIXME: should probably raise an exception if trying to create a new entity with the
         # same name or id as an existing entity. (Go away and use update instead.)
         if entity['id']
           existing_name = redis.hget("entity:#{entity['id']}", 'name')
@@ -132,7 +132,8 @@ module Flapjack
       end
 
       def contacts
-        contact_ids = @redis.smembers("contacts_for:#{id}")
+        contact_ids = @redis.smembers("contacts_for:#{id}") +
+          @redis.smembers("contacts_for:ALL")
 
         if @logger
           @logger.debug("#{contact_ids.length} contact(s) for #{id} (#{name}): " +


### PR DESCRIPTION
This allows users to bypass the current entity -> contacts relationship constraints.

A user can create an entity "ALL", having a common set of contacts, shared amongst all entities/events.
