### PR TITLE
Added regex support for notification rule tags.

### DIFF
--- a/lib/flapjack/data/notification_rule.rb
+++ b/lib/flapjack/data/notification_rule.rb
@@ -90,7 +90,13 @@ module Flapjack
       # tags match?
       def match_tags?(event_tags)
         return false unless @tags && @tags.length > 0
-        @tags.subset?(event_tags)
+        matches = 0
+        event_tags.each do |event_tag|
+          @tags.each do |tag|
+            matches += 1 if /^#{tag}$/ === event_tag
+          end
+        end
+        matches >= @tags.length
       end
 
       def blackhole?(severity)

--- a/spec/lib/flapjack/data/notification_rule_spec.rb
+++ b/spec/lib/flapjack/data/notification_rule_spec.rb
@@ -26,12 +26,30 @@ describe Flapjack::Data::NotificationRule, :redis => true do
     }
   }
 
+  let(:regex_rule_data) {
+    {:contact_id         => '23',
+     :tags               => ["data.*","physical|bare_metal"],
+     :entities           => ["foo-app-01.example.com"],
+     :time_restrictions  => [ weekdays_8_18 ],
+     :unknown_media      => [],
+     :warning_media      => ["email"],
+     :critical_media     => ["sms", "email"],
+     :unknown_blackhole  => false,
+     :warning_blackhole  => false,
+     :critical_blackhole => false
+    }
+  }
+
   let(:rule_id) { 'ABC123' }
 
   let(:timezone) { ActiveSupport::TimeZone.new("Europe/Moscow") }
 
   let(:existing_rule) {
     Flapjack::Data::NotificationRule.add(rule_data, :redis => @redis)
+  }
+
+  let(:existing_regex_rule) {
+    Flapjack::Data::NotificationRule.add(regex_rule_data, :redis => @redis)
   }
 
   it "checks that a notification rule exists" do
@@ -80,6 +98,15 @@ describe Flapjack::Data::NotificationRule, :redis => true do
 
   it "checks whether entity tags match" do
     rule = existing_rule
+
+    expect(rule.match_tags?(['database', 'physical'].to_set)).to be true
+    expect(rule.match_tags?(['database', 'physical', 'beetroot'].to_set)).to be true
+    expect(rule.match_tags?(['database'].to_set)).to be false
+    expect(rule.match_tags?(['virtual'].to_set)).to be false
+  end
+
+  it "checks whether entity tags match a regex" do
+    rule = existing_regex_rule
 
     expect(rule.match_tags?(['database', 'physical'].to_set)).to be true
     expect(rule.match_tags?(['database', 'physical', 'beetroot'].to_set)).to be true


### PR DESCRIPTION
Feature that allows one to specify a regex-based tag within a notification rule. The regex will be compared to each event tags to determine a match.
