### PR TITLE
Added regex support for notification rule tags.

### DIFF
--- a/lib/flapjack/data/contact.rb
+++ b/lib/flapjack/data/contact.rb
@@ -247,6 +247,7 @@ module Flapjack
           rule = self.add_notification_rule({
               :entities           => [],
               :tags               => Flapjack::Data::TagSet.new([]),
+              :regex_tags         => Flapjack::Data::TagSet.new([]),
               :time_restrictions  => [],
               :warning_media      => ALL_MEDIA,
               :critical_media     => ALL_MEDIA,

--- a/lib/flapjack/data/notification.rb
+++ b/lib/flapjack/data/notification.rb
@@ -143,14 +143,16 @@ module Flapjack
             # matchers are rules of the contact that have matched the current event
             # for time, entity and tags
             matchers = rules.select do |rule|
-              logger.debug("considering rule with entities: #{rule.entities} and tags: #{rule.tags.to_json}")
-              rule_has_tags     = rule.tags     ? (rule.tags.length > 0)     : false
-              rule_has_entities = rule.entities ? (rule.entities.length > 0) : false
+              logger.debug("considering rule with entities: #{rule.entities}, tags: #{rule.tags.to_json} and regex tags: #{rule.regex_tags.to_json}")
+              rule_has_tags       = rule.tags       ? (rule.tags.length > 0)       : false
+              rule_has_regex_tags = rule.regex_tags ? (rule.regex_tags.length > 0) : false
+              rule_has_entities   = rule.entities   ? (rule.entities.length > 0)   : false
 
-              matches_tags   = rule_has_tags     ? rule.match_tags?(@tags)       : true
-              matches_entity = rule_has_entities ? rule.match_entity?(@event_id) : true
+              matches_tags       = rule_has_tags       ? rule.match_regex_tags?(@tags) : true
+              matches_regex_tags = rule_has_regex_tags ? rule.match_regex_tags?(@tags) : true
+              matches_entity     = rule_has_entities   ? rule.match_entity?(@event_id) : true
 
-              ((matches_entity && matches_tags) || ! rule.is_specific?) &&
+              ((matches_entity && matches_tags && matches_regex_tags) || ! rule.is_specific?) &&
                 rule_occurring_now?(rule, :contact => contact, :default_timezone => default_timezone)
             end
 

--- a/lib/flapjack/data/notification_rule.rb
+++ b/lib/flapjack/data/notification_rule.rb
@@ -12,8 +12,8 @@ module Flapjack
 
       extend Flapjack::Utility
 
-      attr_accessor :id, :contact_id, :entities, :tags, :time_restrictions,
-        :unknown_media, :warning_media, :critical_media,
+      attr_accessor :id, :contact_id, :entities, :tags, :regex_tags,
+        :time_restrictions, :unknown_media, :warning_media, :critical_media,
         :unknown_blackhole, :warning_blackhole, :critical_blackhole
 
       def self.exists_with_id?(rule_id, options = {})
@@ -74,7 +74,7 @@ module Flapjack
       end
 
       def to_json(*args)
-        self.class.hashify(:id, :contact_id, :tags, :entities,
+        self.class.hashify(:id, :contact_id, :tags, :regex_tags, :entities,
             :time_restrictions, :unknown_media, :warning_media, :critical_media,
             :unknown_blackhole, :warning_blackhole, :critical_blackhole) {|k|
           [k, self.send(k)]
@@ -90,23 +90,19 @@ module Flapjack
       # tags match?
       def match_tags?(event_tags)
         return false unless @tags && @tags.length > 0
+        @tags.subset?(event_tags)
+      end
+
+      # regex_tags match?
+      def match_regex_tags?(event_tags)
+        return false unless @regex_tags && @regex_tags.length > 0
         matches = 0
-        rule_uses_regex = false
         event_tags.each do |event_tag|
-          @tags.each do |tag|
-            if tag.start_with?('regex:')
-              if /^#{tag.split('regex:').last}$/ === event_tag
-                matches += 1
-                rule_uses_regex = true
-              end
-            end
+          @regex_tags.each do |regex_tag|
+            matches += 1 if /#{regex_tag}/ === event_tag
           end
         end
-        if rule_uses_regex
-          matches >= @tags.length
-        else
-          @tags.subset?(event_tags)
-        end
+        matches >= @regex_tags.length
       end
 
       def blackhole?(severity)
@@ -128,7 +124,8 @@ module Flapjack
 
       def is_specific?
         (!@entities.nil? && !@entities.empty?) ||
-          (!@tags.nil? && !@tags.empty?)
+          (!@tags.nil? && !@tags.empty?) ||
+          (!@regex_tags.nil? && !@regex_tags.empty?)
       end
 
     private
@@ -153,6 +150,9 @@ module Flapjack
         if rule_data[:tags].is_a?(Array)
           rule_data[:tags] = Flapjack::Data::TagSet.new(rule_data[:tags])
         end
+        if rule_data[:regex_tags].is_a?(Array)
+          rule_data[:regex_tags] = Flapjack::Data::TagSet.new(rule_data[:regex_tags])
+        end
         rule_data
       end
 
@@ -166,12 +166,14 @@ module Flapjack
         return errors unless errors.nil? || errors.empty?
 
         # whitelisting fields, rather than passing through submitted data directly
-        tag_data = rule_data[:tags].is_a?(Set) ? rule_data[:tags].to_a : nil
+        tag_data       = rule_data[:tags].is_a?(Set) ? rule_data[:tags].to_a : nil
+        regex_tag_data = rule_data[:regex_tags].is_a?(Set) ? rule_data[:regex_tags].to_a : nil
         json_rule_data = {
           :id                 => rule_data[:id].to_s,
           :contact_id         => rule_data[:contact_id].to_s,
           :entities           => Oj.dump(rule_data[:entities]),
           :tags               => Oj.dump(tag_data),
+          :regex_tags         => Oj.dump(regex_tag_data),
           :time_restrictions  => Oj.dump(rule_data[:time_restrictions], :mode => :compat),
           :unknown_media      => Oj.dump(rule_data[:unknown_media]),
           :warning_media      => Oj.dump(rule_data[:warning_media]),
@@ -266,6 +268,12 @@ module Flapjack
                  d[:tags].all? {|et| et.is_a?(String)} ) } =>
         "tags must be a tag_set of strings",
 
+        proc {|d| !d.has_key?(:regex_tags) ||
+               ( d[:regex_tags].nil? ||
+                 d[:regex_tags].is_a?(Flapjack::Data::TagSet) &&
+                 d[:regex_tags].all? {|et| et.is_a?(String)} ) } =>
+        "regex_tags must be a tag_set of strings",
+
         proc {|d| !d.has_key?(:time_restrictions) ||
                ( d[:time_restrictions].nil? ||
                  d[:time_restrictions].all? {|tr|
@@ -334,6 +342,8 @@ module Flapjack
         @contact_id         = rule_data['contact_id']
         tags                = Oj.load(rule_data['tags'] || '')
         @tags               = tags ? Flapjack::Data::TagSet.new(tags) : nil
+        regex_tags          = Oj.load(rule_data['regex_tags'] || '')
+        @regex_tags         = regex_tags ? Flapjack::Data::TagSet.new(regex_tags) : nil
         @entities           = Oj.load(rule_data['entities'] || '')
         @time_restrictions  = Oj.load(rule_data['time_restrictions'] || '')
         @unknown_media      = Oj.load(rule_data['unknown_media'] || '')

--- a/lib/flapjack/gateways/api/contact_methods.rb
+++ b/lib/flapjack/gateways/api/contact_methods.rb
@@ -144,7 +144,7 @@ module Flapjack
 
             contact = find_contact(params[:contact_id])
 
-            rule_data = hashify(:entities, :tags,
+            rule_data = hashify(:entities, :tags, :regex_tags,
               :unknown_media, :warning_media, :critical_media, :time_restrictions,
               :unknown_blackhole, :warning_blackhole, :critical_blackhole) {|k| [k, params[k]]}
 
@@ -167,7 +167,7 @@ module Flapjack
             rule = find_rule(params[:id])
             contact = find_contact(rule.contact_id)
 
-            rule_data = hashify(:entities, :tags,
+            rule_data = hashify(:entities, :tags, :regex_tags,
               :unknown_media, :warning_media, :critical_media, :time_restrictions,
               :unknown_blackhole, :warning_blackhole, :critical_blackhole) {|k| [k, params[k]]}
 

--- a/lib/flapjack/gateways/web/views/contact.html.erb
+++ b/lib/flapjack/gateways/web/views/contact.html.erb
@@ -103,6 +103,7 @@
       <th>ID</th>
       <th>Entities</th>
       <th>Tags</th>
+      <th>Regex Tags</th>
       <th>Warning Media</th>
       <th>Critical Media</th>
       <th>Time Restrictions</th>
@@ -113,6 +114,7 @@
         <td><%= h rule.id %></td>
         <td><%= h( (rule.entities && !rule.entities.empty?) ? rule.entities.join(', ') : '-') %></td>
         <td><%= h( (rule.tags && !rule.tags.empty?) ? rule.tags.to_a.join(', ') : '-') %></td>
+        <td><%= h( (rule.regex_tags && !rule.regex_tags.empty?) ? rule.regex_tags.to_a.join(', ') : '-') %></td>
         <td><%= h( (rule.warning_media && !rule.warning_media.empty?) ? rule.warning_media.join(', ') : '-')%></td>
         <td><%= h( (rule.critical_media && !rule.critical_media.empty?) ? rule.critical_media.join(', ') : '-') %></td>
         <td><%= h(rule.time_restrictions) %></td>

--- a/spec/lib/flapjack/data/notification_rule_spec.rb
+++ b/spec/lib/flapjack/data/notification_rule_spec.rb
@@ -15,6 +15,7 @@ describe Flapjack::Data::NotificationRule, :redis => true do
   let(:rule_data) {
     {:contact_id         => '23',
      :tags               => ["database","physical"],
+     :regex_tags         => [],
      :entities           => ["foo-app-01.example.com"],
      :time_restrictions  => [ weekdays_8_18 ],
      :unknown_media      => [],
@@ -28,7 +29,8 @@ describe Flapjack::Data::NotificationRule, :redis => true do
 
   let(:regex_rule_data) {
     {:contact_id         => '23',
-     :tags               => ["regex:data.*","regex:physical|bare_metal"],
+     :tags               => [],
+     :regex_tags         => ["^data.*$","^(physical|bare_metal)$"],
      :entities           => ["foo-app-01.example.com"],
      :time_restrictions  => [ weekdays_8_18 ],
      :unknown_media      => [],
@@ -108,10 +110,10 @@ describe Flapjack::Data::NotificationRule, :redis => true do
   it "checks whether entity tags match a regex" do
     rule = existing_regex_rule
 
-    expect(rule.match_tags?(['database', 'physical'].to_set)).to be true
-    expect(rule.match_tags?(['database', 'physical', 'beetroot'].to_set)).to be true
-    expect(rule.match_tags?(['database'].to_set)).to be false
-    expect(rule.match_tags?(['virtual'].to_set)).to be false
+    expect(rule.match_regex_tags?(['database', 'physical'].to_set)).to be true
+    expect(rule.match_regex_tags?(['database', 'physical', 'beetroot'].to_set)).to be true
+    expect(rule.match_regex_tags?(['database'].to_set)).to be false
+    expect(rule.match_regex_tags?(['virtual'].to_set)).to be false
   end
 
   it "checks if blackhole settings for a rule match a severity level" do

--- a/spec/lib/flapjack/gateways/api/contact_methods_spec.rb
+++ b/spec/lib/flapjack/gateways/api/contact_methods_spec.rb
@@ -42,6 +42,7 @@ describe 'Flapjack::Gateways::API::ContactMethods', :sinatra => true, :logger =>
   let(:notification_rule_data) {
     {"contact_id"         => "21",
      "tags"               => ["database","physical"],
+     "regex_tags"         => ["^data.*$","^(physical|bare_metal)$"],
      "entities"           => ["foo-app-01.example.com"],
      "time_restrictions"  => nil,
      "unknown_media"      => ["jabber"],

--- a/spec/lib/flapjack/gateways/jsonapi/contact_methods_spec.rb
+++ b/spec/lib/flapjack/gateways/jsonapi/contact_methods_spec.rb
@@ -44,6 +44,7 @@ describe 'Flapjack::Gateways::JSONAPI::ContactMethods', :sinatra => true, :logge
   let(:notification_rule_data) {
     {"contact_id"         => "21",
      "tags"               => ["database","physical"],
+     "regex_tags"         => ["^data.*$","^(physical|bare_metal)$"],
      "entities"           => ["foo-app-01.example.com"],
      "time_restrictions"  => nil,
      "unknown_media"      => ["jabber"],


### PR DESCRIPTION
Feature that allows one to specify a regex-based tag within a notification rule. The regex will be compared to each event tags to determine a match.
