### PR TITLE
[UPDATE] allow email messages to have custom from address

### DIFF
--- a/lib/flapjack/gateways/email.rb
+++ b/lib/flapjack/gateways/email.rb
@@ -51,6 +51,7 @@ module Flapjack
           host = @smtp_config ? @smtp_config['host'] : nil
           port = @smtp_config ? @smtp_config['port'] : nil
           starttls = @smtp_config ? !! @smtp_config['starttls'] : nil
+          m_from = @smtp_config ? @smtp_config['from'] : "flapjack@#{@fqdn}"
           if @smtp_config
             if auth_config = @smtp_config['auth']
               auth = {}
@@ -60,7 +61,6 @@ module Flapjack
             end
           end
 
-          m_from = "flapjack@#{@fqdn}"
           @logger.debug("flapjack_mailer: set from to #{m_from}")
 
           mail = prepare_email(:from       => m_from,
@@ -176,4 +176,3 @@ module Flapjack
     end
   end
 end
-

--- a/spec/lib/flapjack/gateways/email_spec.rb
+++ b/spec/lib/flapjack/gateways/email_spec.rb
@@ -3,7 +3,42 @@ require 'flapjack/gateways/email'
 
 describe Flapjack::Gateways::Email, :logger => true do
 
-  it "sends a mail with text and html parts" do
+  it "can have a custom from email address" do
+    email = double('email')
+    redis = double('redis')
+
+    expect(EM::P::SmtpClient).to receive(:send).with(
+      hash_including(host: 'localhost',
+                     port: 25,
+                     from: "from@example.org")
+    ).and_return(email)
+
+    response = double(response)
+    expect(response).to receive(:"respond_to?").with(:code).and_return(true)
+    expect(response).to receive(:code).and_return(250)
+
+    expect(EM::Synchrony).to receive(:sync).with(email).and_return(response)
+
+    notification = {'notification_type'   => 'recovery',
+                    'contact_first_name'  => 'John',
+                    'contact_last_name'   => 'Smith',
+                    'state'               => 'ok',
+                    'state_duration'      => 2,
+                    'summary'             => 'smile',
+                    'last_state'          => 'problem',
+                    'last_summary'        => 'frown',
+                    'time'                => Time.now.to_i,
+                    'event_id'            => 'example.com:ping'}
+
+    config = {"smtp_config" => {'from' => 'from@example.org'}}
+    Flapjack::Gateways::Email.instance_variable_set('@config', config)
+    Flapjack::Gateways::Email.instance_variable_set('@redis', redis)
+    Flapjack::Gateways::Email.instance_variable_set('@logger', @logger)
+    Flapjack::Gateways::Email.start
+    Flapjack::Gateways::Email.perform(notification)
+  end
+
+  it "sends a mail with text, html parts and default from address" do
     email = double('email')
 
     entity_check = double(Flapjack::Data::EntityCheck)
@@ -12,7 +47,9 @@ describe Flapjack::Gateways::Email, :logger => true do
     # TODO better checking of what gets passed here
     expect(EM::P::SmtpClient).to receive(:send).with(
       hash_including(:host    => 'localhost',
-                     :port    => 25)).and_return(email)
+                     :port    => 25,
+                     :from    => "flapjack@example.com"
+                    )).and_return(email)
 
     response = double(response)
     expect(response).to receive(:"respond_to?").with(:code).and_return(true)
@@ -35,6 +72,7 @@ describe Flapjack::Gateways::Email, :logger => true do
     Flapjack::Gateways::Email.instance_variable_set('@redis', redis)
     Flapjack::Gateways::Email.instance_variable_set('@logger', @logger)
     Flapjack::Gateways::Email.start
+    Flapjack::Gateways::Email.instance_variable_set('@fqdn', "example.com")
     Flapjack::Gateways::Email.perform(notification)
   end
 


### PR DESCRIPTION
In 1972 a crack commando unit was sent to prison by a military court for a crime they didn't commit....

Because it is worthwhile having a custom from field when sending out notification emails. The biggest culprit in the 'where did this email come from' is amazon aws and their default hostnames.
