### PR TITLE
Highlight the section we're in, in the navigation. Fixes #483.

### DIFF
--- a/lib/flapjack/gateways/web.rb
+++ b/lib/flapjack/gateways/web.rb
@@ -85,7 +85,7 @@ module Flapjack
         end
 
         def include_active?(path)
-          request.path == "/#{path}" ? "class='active'" : ""
+          request.path == "/#{path}" ? " class='active'" : ""
         end
       end
 

--- a/lib/flapjack/gateways/web/views/layout.erb
+++ b/lib/flapjack/gateways/web/views/layout.erb
@@ -33,37 +33,37 @@
       <div class="collapse navbar-collapse navbar-ex1-collapse">
 
         <ul class="nav navbar-nav">
-          <li <%= include_active?('') %>>
+          <li<%= include_active?('') %>>
             <a title="Summary" href="/">
               <i class="fa fa-trophy fa-lg"></i>
               Summary
             </a>
           </li>
-          <li <%= include_active?('entities_all') %>>
+          <li<%= include_active?('entities_all') %>>
             <a title="All Entities" href="/entities_all">
               <i class="fa fa-bullseye fa-lg"></i>
               All Entities
             </a>
           </li>
-          <li <%= include_active?('entities_failing') %>>
+          <li<%= include_active?('entities_failing') %>>
             <a title="Failing Entities" href="/entities_failing">
               <i class="fa fa-bullhorn fa-lg"></i>
               Failing Entities
             </a>
           </li>
-          <li <%= include_active?('checks_all') %>>
+          <li<%= include_active?('checks_all') %>>
             <a title="All Checks" href="/checks_all">
               <i class="fa fa-check-circle-o fa-lg"></i>
               All Checks
             </a>
           </li>
-          <li <%= include_active?('checks_failing') %>>
+          <li<%= include_active?('checks_failing') %>>
             <a title="Failing Checks" href="/checks_failing">
               <i class="fa fa-times-circle-o fa-lg"></i>
               Failing Checks
             </a>
           </li>
-          <li <%= include_active?('contacts') %>>
+          <li<%= include_active?('contacts') %>>
             <a title="Contacts" href="/contacts">
               <i class="fa fa-users fa-lg"></i>
               Contacts
@@ -72,7 +72,7 @@
         </ul>
 
         <ul class="nav navbar-nav navbar-right">
-          <li <%= include_active?('self_stats') %>>
+          <li<%= include_active?('self_stats') %>>
             <a title="Internal Statistics" href="/self_stats">
               <i class="fa fa-tachometer fa-lg"></i>
               Internal Statistics


### PR DESCRIPTION
Looks like this:

![image](https://cloud.githubusercontent.com/assets/12306/2869228/2e2dba9c-d25e-11e3-9010-f3ab36143589.png)

The request in #483 raises some problems with the way we structure our navigation right now. 

If I click on "All Checks", then click on a link to an entity, I lose context about where I am in the navigation. 

It's likely there's duplication in the navigation, and we should streamline it to look something like this:

![image](https://cloud.githubusercontent.com/assets/12306/2869222/ef507242-d25d-11e3-9eba-d8ef5fadd152.png)

Entities + checks become dropdowns where you can select all/failing/in maintenance/etc. 
