### PR TITLE
Add a CONTRIBUTING.md doc for potential helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+#Contributing to ![Flapjack](https://raw.github.com/flapjack/flapjack/gh-pages/images/flapjack-2013-notext-transparent-50-50.png "Flapjack") Flapjack
+
+[![Build Status](https://travis-ci.org/flapjack/flapjack.png)](https://travis-ci.org/flapjack/flapjack)
+
+Please see the [Contributing to Flapjack](https://github.com/flapjack/flapjack/wiki/DEVELOPING) section of the Flapjack wiki.
+
+> Flapjack is, and will continue to be, well tested. Monitoring is like continuous integration for production apps, so why shouldn't your monitoring system have tests?
+
+## Quick Start
+
+1. clone the repo
+
+        git clone https://github.com/flapjack/flapjack.git
+
+2. install development dependencies with bundler:
+
+        cd flapjack
+        gem install bundler
+        bundle install
+
+3. install redis
+4. run unit tests
+
+        rake spec
+
+5. run integration tests
+
+        rake features
+
+6. code coverage for tests
+
+        COVERAGE=x rake spec
+        COVERAGE=x rake features
+
+7. make changes with tests, send a [pull request](https://help.github.com/articles/creating-a-pull-request), share love!


### PR DESCRIPTION
CONTRIBUTING file shows potential contributers how to get the code
checked out and running and explains expectations for
code/tests/documentation.

> github "display[s] a link to the CONTRIBUTING file when a user creates
> an Issue or opens a Pull Request" see
> https://github.com/blog/1184-contributing-guidelines

More documentation :heart: from #monitorama
