### PR TITLE
[#495] allow override of redis options for env=test

### DIFF
--- a/etc/flapjack_config.yaml.example
+++ b/etc/flapjack_config.yaml.example
@@ -291,5 +291,4 @@ development:
 
 test:
   redis:
-    database: 14
-
+    db: 14

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,6 +5,7 @@ require 'delorean'
 require 'chronic'
 require 'active_support/time'
 require 'ice_cube'
+require 'flapjack/configuration'
 require 'flapjack/data/entity_check'
 require 'flapjack/data/event'
 
@@ -23,6 +24,8 @@ end
 
 ENV["FLAPJACK_ENV"] = 'test'
 FLAPJACK_ENV = 'test'
+FLAPJACK_ROOT   = File.join(File.dirname(__FILE__), '..', '..')
+FLAPJACK_CONFIG = File.join(FLAPJACK_ROOT, 'etc', 'flapjack_config.yaml')
 
 $: << File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'lib'))
 
@@ -119,7 +122,10 @@ EXPIRE_AS_IF_AT
 
 end
 
-redis_opts = { :db => 14, :driver => :ruby }
+config = Flapjack::Configuration.new
+redis_opts = config.load(FLAPJACK_CONFIG) ?
+             config.for_redis :
+             {:db => 14, :driver => :ruby}
 redis = ::Redis.new(redis_opts)
 redis.flushdb
 RedisDelorean.before_all(:redis => redis)

--- a/lib/flapjack/configuration.rb
+++ b/lib/flapjack/configuration.rb
@@ -38,6 +38,7 @@ module Flapjack
 
       redis_path = (redis['path'] || nil)
       base_opts = {:db => (redis['db'] || 0)}
+      base_opts[:driver] = redis['driver'] if redis['driver']
       redis_config = base_opts.merge(
         (redis_path ? { :path => redis_path } :
                       { :host => (redis['host'] || '127.0.0.1'),


### PR DESCRIPTION
This change allows developers to override redis options for testing by using the test.redis keyspace in the local `etc/flapjack_config.yaml` file.

Previously, spec and cucumber tests had redis options hardcoded as `{ db => 14, :driver => :ruby }`.  

I noticed because I had an old (2.2) redis running on the default port.  

Changes:
- default test values for when no config file is found.
  - must have `:driver => :ruby` to avoid `evma_connect_to_server` errors
  - travis-ci redis-server is on `localhost:6379`, version 2.8 for ruby projects.
  - example yaml must use 'db' key rather than 'database',
    constrained by allowed key processing in `for_redis()`.
    from `flapjack/configuration`.
- adds `:driver` to allowed key processing in `for_redis()`.
- spec_helper change ends up reading the config before every redis test, which is a waste.  My spec/ruby skills were not up to the task of sharing the data from a `config.before(:suite)` test
- `features/support/env.rb` contains redis config for cucumber acceptance tests
