### PR TITLE
fixes #518 - queued events graph now uses jsonapi

### DIFF
--- a/lib/flapjack/gateways/jsonapi/metrics_methods.rb
+++ b/lib/flapjack/gateways/jsonapi/metrics_methods.rb
@@ -76,7 +76,8 @@ module Flapjack
           app.helpers Flapjack::Gateways::JSONAPI::MetricsMethods::Helpers
 
           app.get %r{^/metrics} do
-            filter = filter_query(params[:filter])
+
+            filter = params[:filter] ? filter_query(params[:filter]) : 'all'
 
             keys = %w(fqdn pid total_keys processed_events event_queue_length check_freshness entities checks)
             keys = keys.find_all {|m| filter.include?(m) } unless filter == 'all'

--- a/lib/flapjack/gateways/web.rb
+++ b/lib/flapjack/gateways/web.rb
@@ -385,8 +385,9 @@ module Flapjack
       end
 
       def self_stats
-        @fqdn         = `/bin/hostname -f`.chomp
-        @pid          = Process.pid
+        @fqdn    = `/bin/hostname -f`.chomp
+        @pid     = Process.pid
+        @api_url = api_url
 
         @dbsize              = redis.dbsize
         @executive_instances = redis.keys("executive_instance:*").inject({}) do |memo, i|

--- a/lib/flapjack/gateways/web/public/js/self_stats.js
+++ b/lib/flapjack/gateways/web/public/js/self_stats.js
@@ -58,9 +58,10 @@ $(document).ready(function() {
   });
 
   function updateData() {
-    $.get('/self_stats.json', function(json) {
+    var api_url = $('div#data-api-url').data('api-url');
+    $.get(api_url + '/metrics?filter=event_queue_length', function(json) {
       var d = new Date().getTime();
-      var value = {x: d, y: json.events_queued}
+      var value = {x: d, y: json.event_queue_length}
       data[0].values.push(value)
 
       // Remove old data, to keep the graph performant

--- a/lib/flapjack/gateways/web/views/self_stats.html.erb
+++ b/lib/flapjack/gateways/web/views/self_stats.html.erb
@@ -6,9 +6,10 @@
   require_js  'nv.d3.min'
   require_js  'self_stats'
 %>
-
-<div class="page-header">
-  <h2>Internal Statistics</h2>
+<div id="data-api-url" data-api-url="<%= @api_url %>">
+  <div class="page-header">
+    <h2>Internal Statistics</h2>
+  </div>
 </div>
 
 <style>


### PR DESCRIPTION
also, /metrics in the jsonapi now assumes filter=all if no filter query param is supplied
