### PR TITLE
Added spec to demonstrate sending full name in email

### DIFF
--- a/etc/flapjack_config.yaml.example
+++ b/etc/flapjack_config.yaml.example
@@ -51,7 +51,7 @@ production:
         level: INFO
         syslog_errors: yes
       smtp_config:
-        #from: "flapjack@noreply.example"
+        #from: "Flapjack Example <flapjack@noreply.example>"
         host: 127.0.0.1
         # 1025 is the default port for http://mailcatcher.me
         port: 1025


### PR DESCRIPTION
Added basic spec to demonstrate using the "Full Name &lt;test@example.com&gt;" convention for using full names via the Mail gem. Example in the `flapjack_config.yaml.example` configuration, as per comments on #542 
