### PR TITLE
make sure that base_url isn't escaped so that links work correctly

### DIFF
--- a/lib/flapjack/gateways/web/views/check.html.erb
+++ b/lib/flapjack/gateways/web/views/check.html.erb
@@ -4,7 +4,7 @@
   current_time = Time.now
 %>
 <div class="page-header">
-  <% entity_link = u(@base_url) + "entity/" << u(@entity) %>
+  <% entity_link = @base_url + "entity/" << u(@entity) %>
   <h2><%= h @check %> on <a href="<%= entity_link %>" title="entity summary"><%= h @entity %></a></h2>
 </div>
 

--- a/lib/flapjack/gateways/web/views/checks.html.erb
+++ b/lib/flapjack/gateways/web/views/checks.html.erb
@@ -21,7 +21,7 @@
   <tbody>
     <% @entities_sorted.each do |entity| %>
       <% row_entity = nil %>
-      <% entity_link = u(@base_url) + "entity/" << u(entity) %>
+      <% entity_link = @base_url + "entity/" << u(entity) %>
       <% @states[entity].each do |check, status, summary, changed, updated, in_unscheduled_outage, in_scheduled_outage, notified| %>
         <%
           row_colour = case status
@@ -33,7 +33,7 @@
             status
           end
 
-          check_link = u(@base_url) + "check?entity=" << u(entity) << "&amp;check=" << u(check)
+          check_link = @base_url + "check?entity=" << u(entity) << "&amp;check=" << u(check)
         %>
         <tr class="<%= row_colour %>">
         <% unless row_entity && entity == row_entity %>

--- a/lib/flapjack/gateways/web/views/contact.html.erb
+++ b/lib/flapjack/gateways/web/views/contact.html.erb
@@ -81,7 +81,7 @@
           <td>
             <% checks.each do |entity_check| %>
               <% entity, check = entity_check.split(':', 2) %>
-              <% check_link = "<a href=\"#{u(@base_url)}check?entity=#{u(entity)}&amp;check=#{u(check)}\" title=\"check status\">" +
+              <% check_link = "<a href=\"#{@base_url}check?entity=#{u(entity)}&amp;check=#{u(check)}\" title=\"check status\">" +
                  h(check) + "</a>"%>
               <a href="<%= @base_url %>entity/<%= u(entity) %>" title="entity status"><%= h entity %></a> ::
               <%= check_link %> <br />
@@ -147,7 +147,7 @@
         <td><a href="<%= @base_url %>entity/<%= u(entity.name) %>" title="entity status"><%= h entity.name %></a></td>
         <td>
           <% checks.each do |check| %>
-          <%= "<a href=\"#{u(@base_url)}check?entity=#{u(entity.name)}&amp;check=#{u(check)}\" title=\"check status\">#{ h check }</a>" %>
+          <%= "<a href=\"#{@base_url}check?entity=#{u(entity.name)}&amp;check=#{u(check)}\" title=\"check status\">#{ h check }</a>" %>
           <% end %>
         </td>
       </tr>

--- a/lib/flapjack/gateways/web/views/entity.html.erb
+++ b/lib/flapjack/gateways/web/views/entity.html.erb
@@ -28,7 +28,7 @@
           status
         end
 
-        check_link = u(@base_url) + "check?entity=" << u(@entity) << "&amp;check=" << u(check)
+        check_link = @base_url + "check?entity=" << u(@entity) << "&amp;check=" << u(check)
 
       %>
       <tr class="<%= row_colour %>">


### PR DESCRIPTION
A regression was introduced recently whereby the base_url for links was accidentally escaped. This resulted in a base_url of / becoming %2F and links breaking.

There is likely a use case whereby the base_url is something like /🍺 which may need to be escaped though we need to make sure that the leading / is left intact.
