### PR TITLE
Update docs to reference github.com/flapjack instead of github.com/flpjck

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ## Building
 
-From your checkout of the [Flapjack repository](https://github.com/flpjck/flapjack):
+From your checkout of the [Flapjack repository](https://github.com/flapjack/flapjack):
 
 ``` bash
 git checkout gh-pages
@@ -23,7 +23,7 @@ This will copy slate documentation from `../slate/build` if it's available.
 
 ### JSONAPI documentation
 
-JSONAPI documentation is in a [separate repository](https://github.com/flpjck/slate).
+JSONAPI documentation is in a [separate repository](https://github.com/flapjack/slate).
 
 There is a task to pull a built copy of the documentation into the Jekyll site:
 

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ task :slate do
       Please ensure you have:
 
        - A checkout of Flapjack's slate documentation at #{source.parent}
-         (Grab the repo from https://github.com/flpjck/slate)
+         (Grab the repo from https://github.com/flapjack/slate)
        - Built a standalone local copy of the slate documentation with a `rake build`.
     ERROR
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,7 +39,7 @@
           <a href="https://twitter.com/jessereynolds">Jesse Reynolds</a> and
           <a href="https://github.com/ali-graham">Ali Graham</a>
           are the primary developers.
-          View the project on <a href="https://github.com/flpjck/flapjack">GitHub</a>.
+          View the project on <a href="https://github.com/flapjack/flapjack">GitHub</a>.
         </div>
         <div class="col-md-4 sponsor">
           <a href="http://bulletproof.net.au" target="_bulletproof">

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -8,7 +8,7 @@ layout: default
  - The [quickstart guide]({{ site.url }}/quickstart) shows you how to get Flapjack running in a VM locally using Vagrant and VirtualBox, and teaches you the basics of working with Flapjack.
  - The [FAQ]({{ site.url }}/docs/faq/) covers common questions asked about Flapjack, and pointers to other resources.
  - The [JSONAPI documentation]({{ site.url }}/docs/jsonapi) covers the API for working with Flapjack data.
- - The [wiki](https://github.com/flpjck/flapjack/wiki) has many guides and in-depth documentation, including how to [debug](https://github.com/flpjck/flapjack/wiki/DEBUGGING) and [develop](https://github.com/flpjck/flapjack/wiki/DEVELOPING) Flapjack.
+ - The [wiki](https://github.com/flapjack/flapjack/wiki) has many guides and in-depth documentation, including how to [debug](https://github.com/flapjack/flapjack/wiki/DEBUGGING) and [develop](https://github.com/flapjack/flapjack/wiki/DEVELOPING) Flapjack.
 
 ## Presentations
 

--- a/docs/jsonapi/build/index.html
+++ b/docs/jsonapi/build/index.html
@@ -70,7 +70,7 @@
 
 <p>Welcome to the documention of the JSON API of <a href="http://flapjack.io">Flapjack</a>.</p>
 
-<p>See the <a href="https://github.com/flpjck/flapjack-diner/">flapjack-diner</a> RubyGem which provides a Ruby consumer of this API.</p>
+<p>See the <a href="https://github.com/flapjack/flapjack-diner/">flapjack-diner</a> RubyGem which provides a Ruby consumer of this API.</p>
 
 <h2 id="required-http-headers">Required HTTP Headers</h2>
 

--- a/docs/jsonapi/build/sections/0_intro.html
+++ b/docs/jsonapi/build/sections/0_intro.html
@@ -60,7 +60,7 @@
 
 <p>Welcome to the documention of the JSON API of <a href="http://flapjack.io">Flapjack</a>.</p>
 
-<p>See the <a href="https://github.com/flpjck/flapjack-diner/">flapjack-diner</a> RubyGem which provides a Ruby consumer of this API.</p>
+<p>See the <a href="https://github.com/flapjack/flapjack-diner/">flapjack-diner</a> RubyGem which provides a Ruby consumer of this API.</p>
 
 <h2 id="required-http-headers">Required HTTP Headers</h2>
 

--- a/docs/jsonapi/index.html
+++ b/docs/jsonapi/index.html
@@ -70,7 +70,7 @@
 
 <p>Welcome to the documention of the JSON API of <a href="http://flapjack.io">Flapjack</a>.</p>
 
-<p>See the <a href="https://github.com/flpjck/flapjack-diner/">flapjack-diner</a> RubyGem which provides a Ruby consumer of this API.</p>
+<p>See the <a href="https://github.com/flapjack/flapjack-diner/">flapjack-diner</a> RubyGem which provides a Ruby consumer of this API.</p>
 
 <h2 id="required-http-headers">Required HTTP Headers</h2>
 

--- a/docs/jsonapi/sections/0_intro.html
+++ b/docs/jsonapi/sections/0_intro.html
@@ -60,7 +60,7 @@
 
 <p>Welcome to the documention of the JSON API of <a href="http://flapjack.io">Flapjack</a>.</p>
 
-<p>See the <a href="https://github.com/flpjck/flapjack-diner/">flapjack-diner</a> RubyGem which provides a Ruby consumer of this API.</p>
+<p>See the <a href="https://github.com/flapjack/flapjack-diner/">flapjack-diner</a> RubyGem which provides a Ruby consumer of this API.</p>
 
 <h2 id="required-http-headers">Required HTTP Headers</h2>
 

--- a/quickstart.markdown
+++ b/quickstart.markdown
@@ -13,7 +13,7 @@ You'll also learn the basics of how to:
 - Simulate a failure of a monitored service
 - Integrate Flapjack with Nagios (or Icinga), so Flapjack takes over alerting
 
-To skip this tutorial and jump straight to the code, view the project on [GitHub](https://github.com/flpjck/flapjack).
+To skip this tutorial and jump straight to the code, view the project on [GitHub](https://github.com/flapjack/flapjack).
 
 ## Getting Flapjack running
 
@@ -29,7 +29,7 @@ To skip this tutorial and jump straight to the code, view the project on [GitHub
 Get the repo, and build your Vagrant box:
 
 ```
-git clone https://github.com/flpjck/vagrant-flapjack.git
+git clone https://github.com/flapjack/vagrant-flapjack.git
 cd vagrant-flapjack
 vagrant up
 ```
@@ -42,7 +42,7 @@ vagrant up --provider=vmware_fusion
 
 <div class="alert alert-info">
 <strong>More information:</strong>
-Check out the <a class="alert-link" href="https://github.com/flpjck/vagrant-flapjack">vagrant-flapjack</a> project on GitHub.
+Check out the <a class="alert-link" href="https://github.com/flapjack/vagrant-flapjack">vagrant-flapjack</a> project on GitHub.
 </div>
 
 ### Verify
@@ -101,7 +101,7 @@ simulate-failed-check --help
 ```
 
 <div class="alert alert-info">
-Details of these commands are available <a class="alert-link" href="https://github.com/flpjck/flapjack/wiki/USING#running">on the Flapjack wiki</a>.
+Details of these commands are available <a class="alert-link" href="https://github.com/flapjack/flapjack/wiki/USING#running">on the Flapjack wiki</a>.
 </div>
 
 ![CLI](/images/quickstart/term-flapjack-help.png)
@@ -145,7 +145,7 @@ All that remains is to configure `flapjack-nagios-receiver` to read from this na
 sudo /etc/init.d/flapjack-nagios-receiver start
 ```
 
-More details on configuration are avilable [on the wiki](https://github.com/flpjck/flapjack/wiki/USING#configuring-components).
+More details on configuration are avilable [on the wiki](https://github.com/flapjack/flapjack/wiki/USING#configuring-components).
 
 ### Verify
 
@@ -155,13 +155,13 @@ Reload the Flapjack web interface and you should now see the checks from Icinga 
 
 ## Create some contacts and Entities
 
-Currently Flapjack does not include a friendly web interface for managing contacts and entities, so for now we use json, curl, and the [Flapjack API](https://github.com/flpjck/flapjack/wiki/API).
+Currently Flapjack does not include a friendly web interface for managing contacts and entities, so for now we use json, curl, and the [Flapjack API](https://github.com/flapjack/flapjack/wiki/API).
 
-The vagrant-flapjack project ships with [example json files](https://github.com/flpjck/vagrant-flapjack/tree/master/examples) that you can use in this tutorial, or you can copy and paste the longform curl commands below that include the json.
+The vagrant-flapjack project ships with [example json files](https://github.com/flapjack/vagrant-flapjack/tree/master/examples) that you can use in this tutorial, or you can copy and paste the longform curl commands below that include the json.
 
 ### Create Contacts Ada and Charles
 
-We'll be using the [POST /contacts](https://github.com/flpjck/flapjack/wiki/API#wiki-post_contacts) API call to create two contacts.
+We'll be using the [POST /contacts](https://github.com/flapjack/flapjack/wiki/API#wiki-post_contacts) API call to create two contacts.
 
 Run the following from your workstation, cd'd into the vagrant-flapjack directory:
 
@@ -236,7 +236,7 @@ Selecting [Ada](http://localhost:3080/contacts/21) should give you something lik
 
 ### Create entities foo-app-01 and foo-db-01 (.example.com)
 
-We'll be using the [POST /entities](https://github.com/flpjck/flapjack/wiki/API#wiki-post_entities) api call to create two entities.
+We'll be using the [POST /entities](https://github.com/flapjack/flapjack/wiki/API#wiki-post_entities) api call to create two entities.
 
 We're going to assign both Ada and Charles to foo-app-01, and just Ada to foo-db-01.
 
@@ -289,7 +289,7 @@ Visit [foo-app-01](http://localhost:3080/entity/foo-app-01.example.com) in the w
 
 ## Feedback?
 
-Found an error in the above? Please [submit a bug report](https://github.com/flpjck/flapjack/issues/new) and/or a pull request against the [gh-pages branch](https://github.com/flpjck/flapjack/tree/gh-pages) with the fix.
+Found an error in the above? Please [submit a bug report](https://github.com/flapjack/flapjack/issues/new) and/or a pull request against the [gh-pages branch](https://github.com/flapjack/flapjack/tree/gh-pages) with the fix.
 
 Something not clear? That's a bug too!
 
@@ -305,6 +305,6 @@ Stay tuned for more info on how to configure:
 
 In the mean time, check out:
 
- - [Documentation](https://github.com/flpjck/flapjack/wiki/IMPORTING) on **how to import contacts and entities**
+ - [Documentation](https://github.com/flapjack/flapjack/wiki/IMPORTING) on **how to import contacts and entities**
  - **[JSONAPI documentation](/docs/jsonapi)** for working with individual contacts and entities
 

--- a/support.markdown
+++ b/support.markdown
@@ -11,9 +11,9 @@ Ask questions on the [Flapjack mailing list](https://groups.google.com/forum/#!f
 
 ## GitHub issues
 
-Report bugs + request features on our [issue tracker](https://github.com/flpjck/flapjack/issues).
+Report bugs + request features on our [issue tracker](https://github.com/flapjack/flapjack/issues).
 
-We also have issue trackers for the [Vagrant box](https://github.com/flpjck/vagrant-flapjack/issues), [packages](https://github.com/flpjck/omnibus-flapjack/issues), and [Ruby API client](https://github.com/flpjck/flapjack-diner/issues)
+We also have issue trackers for the [Vagrant box](https://github.com/flapjack/vagrant-flapjack/issues), [packages](https://github.com/flapjack/omnibus-flapjack/issues), and [Ruby API client](https://github.com/flapjack/flapjack-diner/issues)
 
 ## IRC
 
@@ -27,4 +27,4 @@ Ping [@auxesis](https://twitter.com/auxesis) (Lindsay Holmwood) or [@jessereynol
 
 We try to cover as much as possible in the [documentation]({ site.url }/docs).
 
-If you find the Flapjack documentation lacking, we consider that a bug! Please create a [GitHub issue](https://github.com/flpjck/flapjack/issues/new) and we'll get it fixed ASAP.
+If you find the Flapjack documentation lacking, we consider that a bug! Please create a [GitHub issue](https://github.com/flapjack/flapjack/issues/new) and we'll get it fixed ASAP.


### PR DESCRIPTION
While the redirect works, it's always nicer to have the correct URL to start with.
