### PR TITLE
Add return code if the end unscheduled maintenance was successful (closes #595)

### DIFF
--- a/lib/flapjack/data/entity_check.rb
+++ b/lib/flapjack/data/entity_check.rb
@@ -270,10 +270,11 @@ module Flapjack
         if (um_start = @redis.get("#{@key}:unscheduled_maintenance"))
           duration = end_time - um_start.to_i
           @logger.debug("ending unscheduled downtime for #{@key} at #{Time.at(end_time).to_s}") if @logger
-          @redis.del("#{@key}:unscheduled_maintenance")
           @redis.zadd("#{@key}:unscheduled_maintenances", duration, um_start) # updates existing UM 'score'
+          @redis.del("#{@key}:unscheduled_maintenance") == 1
         else
           @logger.debug("end_unscheduled_maintenance called for #{@key} but none found") if @logger
+          true
         end
       end
 


### PR DESCRIPTION
In end_unscheduled_maintenance, the last command executed is @redis.zadd("#{@key}:unscheduled_maintenances", duration, um_start). This returns false, as this key already exists, having been added in create_unscheduled_maintenance.

Why does this key exist, and is it intended to be used somewhere?

The actual work here is done by @redis.del("#{@key}:unscheduled_maintenance"), which returns one if successful. I suggest we make the success of this the return of the function, where it returns a proper boolean if the maintenance was deleted.
