### PR TITLE
Change the reporting in the Pagerduty UI so the hostname is visible

### DIFF
--- a/lib/flapjack/gateways/pagerduty.rb
+++ b/lib/flapjack/gateways/pagerduty.rb
@@ -163,6 +163,13 @@ module Flapjack
       end
 
       def send_pagerduty_event(event)
+        # Setting the HOSTNAME and the SERVICE makes them visible in the Pagerduty UI
+        begin
+          details = event['incident_key'].split(":")
+          event['details'] = { "HOSTNAME" => details[0], "SERVICE" => details[1] }
+        rescue
+          @logger.debug "Unable to set the keys needed for Pagerduty UI #{event.inspect}"
+        end
         options  = { :body => Oj.dump(event) }
         http = EM::HttpRequest.new(PAGERDUTY_EVENTS_API_URL).post(options)
         response = Oj.load(http.response)


### PR DESCRIPTION
Set the details in the event so the reporting entity name is visible in the Pagerduty UI
