### PR TITLE
Add the maint subcommand to the chat bot to fix #664

### DIFF
--- a/lib/flapjack/gateways/jabber.rb
+++ b/lib/flapjack/gateways/jabber.rb
@@ -241,6 +241,7 @@ module Flapjack
           msg = "commands: \n" +
                 "  ACKID <id> <comment> [duration: <time spec>]\n" +
                 "  ack entities /pattern/ <comment> [duration: <time spec>]\n" +
+                "  maint entities /pattern/ <comment> [(start-in|start-at): <time spec>] [duration: <time spec>]\n" +
                 "  status entities /pattern/\n" +
                 "  ack checks /check_pattern/ on /entity_pattern/ <comment> [duration: <time spec>]\n" +
                 "  status checks /check_pattern/ on /entity_pattern/\n" +
@@ -417,6 +418,65 @@ module Flapjack
                 }
             else
               msg = "found no matching entities with failing checks"
+            end
+          else
+            msg = "that doesn't seem to be a valid pattern - /#{pattern}/"
+          end
+        end
+          
+        when /^(?:maint )?entities\s+\/(.+)\/(?:\s*(.*?)(?:\s*start-in:.*?(\w+.*?))?(?:\s*start-at:.*?(\w+.*?))?(?:\s*duration:.*?(\w+.*?))?)$/i
+          entity_pattern   = $1.strip
+          comment          = $2 ? $2.strip : nil
+          start_in         = $3 ? $3.strip : nil
+          start_at         = $4 ? $4.strip : nil
+          duration_str     = $5 ? $5.strip : '1 hour'
+          maint_duration   = ChronicDuration.parse(duration_str)
+          entity_names     = Flapjack::Data::Entity.find_all_name_matching(entity_pattern, :redis => @redis)
+
+          if comment.nil? || (comment.length == 0)
+            comment = "#{from}: Set via chatbot"
+          else
+            comment = "#{from}: #{comment}"
+          end
+
+          if start_in 
+            maint_start = Time.now.to_i + ChronicDuration.parse(start_in)
+          elsif start_at
+            maint_start = Chronic.parse(start_at).to_i
+          else
+            maint_start = Time.now.to_i
+          end
+
+          if entity_names
+            number_found = entity_names.length
+            case
+            when number_found == 0
+              msg = "found no entities matching /#{pattern}/"
+            when number_found >= 1
+              entities = entity_names.map {|name|
+                Flapjack::Data::Entity.find_by_name(name, :redis => @redis)
+              }.compact.inject({}) {|memo, entity|
+                memo[entity] = entity.check_list.sort
+                memo
+              }
+              if entities.length >= 1
+                entities.each_pair do |entity,check_list|
+                  check_list.each do |check|
+                    entity_check = Flapjack::Data::EntityCheck.for_entity(entity, check, :redis => @redis)
+                    entity_check.create_scheduled_maintenance(
+                      maint_start,
+                      maint_duration,
+                      :summary => comment,
+                      )
+                    entity_check.update_current_scheduled_maintenance
+                  end
+                end
+                msg = entities.inject("Maint list:\n") {|memo,kv|
+                  kv[1].each {|e| memo << "#{kv[0].name}:#{e}\n" }
+                  memo
+                }
+            else
+              msg = "found no matching entities with active checks"
             end
           else
             msg = "that doesn't seem to be a valid pattern - /#{pattern}/"


### PR DESCRIPTION
users can use 'start-in' to say things like the maint should start in '1 hour', '1 day' etc.

flapjack-dev: maint entities /cs-s-hbase03.eng.jiveland.com/ testing start-in: 1 minute duration: 10 minutes

Or 'start-at' to give a specific date/hour to start at like '2014-01-01 07:00'

flapjack-dev: maint entities /collins.jcadev/ test9 start-at: 2014-01-01 07:00 duration: 12 hours

Additionally the user can just rely on the defaults and get a 1 hour maint starting now.