### PR TITLE
Add last_change field to status_reports in the API (closes: #678)

### DIFF
--- a/lib/flapjack/gateways/jsonapi/check_presenter.rb
+++ b/lib/flapjack/gateways/jsonapi/check_presenter.rb
@@ -28,6 +28,7 @@ module Flapjack
            'in_unscheduled_maintenance'        => @entity_check.in_unscheduled_maintenance?,
            'in_scheduled_maintenance'          => @entity_check.in_scheduled_maintenance?,
            'last_update'                       => @entity_check.last_update,
+           'last_change'                       => @entity_check.last_change,
            'last_problem_notification'         => @entity_check.last_notification_for_state(:problem)[:timestamp],
            'last_recovery_notification'        => @entity_check.last_notification_for_state(:recovery)[:timestamp],
            'last_acknowledgement_notification' => @entity_check.last_notification_for_state(:acknowledgement)[:timestamp]}


### PR DESCRIPTION
This now returns:

```
flapjack-diner ➤ curl http://localhost:3081/status_report/checks/foo-app-01:HTTP | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   639  100   639    0     0  64253      0 --:--:-- --:--:-- --:--:-- 71000
{
   "status_reports" : [
      {
         "details" : "",
         "in_scheduled_maintenance" : true,
         "name" : "HTTP",
         "last_problem_notification" : null,
         "state" : "ok",
         "summary" : "Simulated check output (test by operator)",
         "enabled" : true,
         "last_update" : 1413271455,
         "last_acknowledgement_notification" : null,
         "perfdata" : null,
         "last_recovery_notification" : null,
         "in_unscheduled_maintenance" : false,
         "last_change" : 1413271455,
         "links" : {
            "entity" : [
               "5c7be7de-2bf0-4b5c-9acf-b591528ef93b"
            ],
            "check" : [
               "foo-app-01:HTTP"
            ]
         }
      }
   ],
   "linked" : {
      "entities" : [
         {
            "id" : "5c7be7de-2bf0-4b5c-9acf-b591528ef93b",
            "name" : "foo-app-01",
            "links" : {
               "checks" : [
                  "foo-app-01:HTTP"
               ]
            }
         }
      ],
      "checks" : [
         {
            "name" : "HTTP",
            "id" : "foo-app-01:HTTP"
         }
      ]
   }
}
```
