### PR TITLE
Fixes issue #578

### DIFF
--- a/lib/flapjack/gateways/jabber.rb
+++ b/lib/flapjack/gateways/jabber.rb
@@ -131,7 +131,7 @@ module Flapjack
             presence << "<x xmlns='http://jabber.org/protocol/muc'><history maxstanzas='0'></x>"
             EventMachine::Synchrony.next_tick do
               write presence
-              say(room, "flapjack jabber gateway started at #{Time.now}, hello! Try typing 'help'.", :groupchat)
+              say(room, "flapjack jabber gateway started at #{Time.now}, hello! Try typing 'help'.", :groupchat) if @config['chatbot_announce']
             end
           end
         end


### PR DESCRIPTION
Coupled with the following config the bot announcing itself into a muc can be disabled.

  gateways:
    jabber:
      enabled: yes
      chatbot_announce: no
