### PR TITLE
make 0.9 compatible with new event mirroring logic in 1.2 (fixes #687)

### DIFF
--- a/lib/flapjack/data/event.rb
+++ b/lib/flapjack/data/event.rb
@@ -3,6 +3,8 @@
 require 'oj'
 require 'flapjack/data/tag_set'
 
+require 'flapjack/data/migration'
+
 module Flapjack
   module Data
     class Event
@@ -78,24 +80,27 @@ module Flapjack
                      :events_archive_maxage => (3 * 60 * 60) }
         options  = defaults.merge(opts)
 
-        archive_dest = nil
+        archive_dest  = nil
         base_time_str = Time.now.utc.strftime("%Y%m%d%H")
 
         if options[:archive_events]
           archive_dest = "events_archive:#{base_time_str}"
+          unless @previous_base_time_str == base_time_str
+            Flapjack::Data::Migration.purge_expired_archive_index(:redis => redis)
+          end
+          @previous_base_time_str = base_time_str
           if options[:block]
             raw = redis.brpoplpush(queue, archive_dest, 0)
           else
             raw = redis.rpoplpush(queue, archive_dest)
             return unless raw
           end
+          redis.sadd("known_events_archive_keys", archive_dest)
+        elsif options[:block]
+          raw = redis.brpop(queue, 0)[1]
         else
-          if options[:block]
-            raw = redis.brpop(queue, 0)[1]
-          else
-            raw = redis.rpop(queue)
-            return unless raw
-          end
+          raw = redis.rpop(queue)
+          return unless raw
         end
         parsed = parse_and_validate(raw, :logger => options[:logger])
         if parsed.nil?

--- a/lib/flapjack/data/migration.rb
+++ b/lib/flapjack/data/migration.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+
+module Flapjack
+  module Data
+    class Migration
+
+      def self.refresh_archive_index(options = {})
+        raise "Redis connection not set" unless redis = options[:redis]
+        archive_keys = redis.keys('events_archive:*')
+        if archive_keys.empty?
+          redis.del('known_events_archive_keys')
+          return
+        end
+
+        grouped_keys = archive_keys.group_by do |ak|
+          (redis.llen(ak) > 0) ? 'add' : 'remove'
+        end
+
+        {'remove' => :srem, 'add' => :sadd}.each_pair do |k, cmd|
+          next unless grouped_keys.has_key?(k) && !grouped_keys[k].empty?
+          redis.send(cmd, 'known_events_archive_keys', grouped_keys[k])
+        end
+      end
+
+      def self.purge_expired_archive_index(options = {})
+        raise "Redis connection not set" unless redis = options[:redis]
+        return unless redis.exists('known_events_archive_keys')
+
+        redis.smembers('known_events_archive_keys').each do |ak|
+          redis.srem('known_events_archive_keys', ak) unless redis.exists(ak)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/flapjack/redis_pool.rb
+++ b/lib/flapjack/redis_pool.rb
@@ -10,14 +10,18 @@ require 'redis'
 
 require 'em-synchrony/connection_pool'
 
+require 'flapjack/data/migration'
+
 module Flapjack
   class RedisPool < EventMachine::Synchrony::ConnectionPool
 
     def initialize(opts = {})
       config = opts.delete(:config)
-      @size = opts[:size] || 5
+      @size  = opts[:size] || 5
       super(:size => @size) {
-        ::Redis.new(config)
+        redis = ::Redis.new(config)
+        Flapjack::Data::Migration.refresh_archive_index(:redis => redis)
+        redis
       }
     end
 

--- a/spec/lib/flapjack/redis_pool_spec.rb
+++ b/spec/lib/flapjack/redis_pool_spec.rb
@@ -12,6 +12,7 @@ describe Flapjack::RedisPool do
         redis
       }
       expect(::Redis).to receive(:new).exactly(redis_count).times.and_return(*redis_conns)
+      expect(Flapjack::Data::Migration).to receive(:refresh_archive_index).exactly(redis_count).times
 
       frp = Flapjack::RedisPool.new(:size => redis_count)
 


### PR DESCRIPTION
fixes #687 
