### PR TITLE
Fix PagerDuty log failure on POST

### DIFF
--- a/lib/flapjack/gateways/pagerduty.rb
+++ b/lib/flapjack/gateways/pagerduty.rb
@@ -298,7 +298,6 @@ module Flapjack
             response = Oj.load(http_response.body)
           rescue Oj::Error
             @logger.error("failed to parse json from a post to #{url} ... response headers and body follows...")
-            return nil
           end
           @logger.debug(http_response.inspect)
           status   = http_response.code


### PR DESCRIPTION
Removes an unnecessary early-exit condition that keeps a crucial log message from being written.
