### PR TITLE
Fix PagerDuty log failure on POST (maint/1.x)

### DIFF
--- a/lib/flapjack/gateways/pagerduty.rb
+++ b/lib/flapjack/gateways/pagerduty.rb
@@ -274,7 +274,6 @@ module Flapjack
           response = Flapjack.load_json(http.response)
         rescue Oj::Error
           @logger.error("failed to parse json from a post to #{url} ... response headers and body follows...")
-          return nil
         end
         status   = http.response_header.status
         @logger.debug(http.response_header.inspect)


### PR DESCRIPTION
Removes an unnecessary early-exit condition that keeps a crucial log message from being written.
