### PR TITLE
Backport notification delays from master

### DIFF
--- a/lib/flapjack.rb
+++ b/lib/flapjack.rb
@@ -4,6 +4,9 @@ require 'oj'
 
 module Flapjack
 
+  DEFAULT_INITIAL_FAILURE_DELAY = 30
+  DEFAULT_REPEAT_FAILURE_DELAY  = 60
+
   def self.load_json(data)
     Oj.load(data, :mode => :strict, :symbol_keys => false)
   end

--- a/lib/flapjack/data/entity_check.rb
+++ b/lib/flapjack/data/entity_check.rb
@@ -606,6 +606,8 @@ module Flapjack
         details = options[:details]
         perfdata = options[:perfdata]
         count = options[:count]
+        initial_failure_delay = options[:initial_failure_delay]
+        repeat_failure_delay = options[:repeat_failure_delay]
 
         old_state = self.state
 
@@ -649,6 +651,8 @@ module Flapjack
 
           # Even if this isn't a state change, we need to update the current state
           # hash summary and details (as they may have changed)
+          multi.hset("check:#{@key}", 'initial_failure_delay', (initial_failure_delay || Flapjack::DEFAULT_INITIAL_FAILURE_DELAY))
+          multi.hset("check:#{@key}", 'repeat_failure_delay', (repeat_failure_delay || Flapjack::DEFAULT_REPEAT_FAILURE_DELAY))
           multi.hset("check:#{@key}", 'summary', (summary || ''))
           multi.hset("check:#{@key}", 'details', (details || ''))
           if perfdata
@@ -775,6 +779,16 @@ module Flapjack
 
         data = [data] if data.is_a?(Hash)
         data
+      end
+
+      def initial_failure_delay
+        delay = @redis.hget("check:#{@key}", 'initial_failure_delay')
+        delay.to_i unless delay.nil?
+      end
+
+      def repeat_failure_delay
+        delay = @redis.hget("check:#{@key}", 'repeat_failure_delay')
+        delay.to_i unless delay.nil?
       end
 
       # Returns a list of states for this entity check, sorted by timestamp.

--- a/lib/flapjack/filters/delays.rb
+++ b/lib/flapjack/filters/delays.rb
@@ -20,8 +20,15 @@ module Flapjack
       include Base
 
       def block?(event, entity_check, previous_state)
-        failure_delay = 30
-        resend_delay  = 60
+        initial_failure_delay = entity_check.initial_failure_delay
+        if initial_failure_delay.nil? || (initial_failure_delay < 1)
+          initial_failure_delay = Flapjack::DEFAULT_INITIAL_FAILURE_DELAY
+        end
+
+        repeat_failure_delay = entity_check.repeat_failure_delay
+        if repeat_failure_delay.nil? || (repeat_failure_delay < 1)
+          repeat_failure_delay = Flapjack::DEFAULT_REPEAT_FAILURE_DELAY
+        end
 
         label = 'Filter: Delays:'
 
@@ -51,18 +58,18 @@ module Flapjack
                       "event.state: [#{event.state.inspect}], " +
                       "last_alert_state == event.state ? #{last_alert_state.to_s == event.state}")
 
-        if current_state_duration < failure_delay
+        if current_state_duration < initial_failure_delay
           @logger.debug("#{label} block - duration of current failure " +
-                     "(#{current_state_duration}) is less than failure_delay (#{failure_delay})")
+                     "(#{current_state_duration}) is less than initial_failure_delay (#{initial_failure_delay})")
           return true
         end
 
-        if !last_problem_alert.nil? && (time_since_last_alert < resend_delay) &&
+        if !last_problem_alert.nil? && (time_since_last_alert < repeat_failure_delay) &&
           (last_alert_state.to_s == event.state)
 
           @logger.debug("#{label} block - time since last alert for " +
                         "current problem (#{time_since_last_alert}) is less than " +
-                        "resend_delay (#{resend_delay}) and last alert state (#{last_alert_state}) " +
+                        "repeat_failure_delay (#{repeat_failure_delay}) and last alert state (#{last_alert_state}) " +
                         "is equal to current event state (#{event.state})")
           return true
         end

--- a/lib/flapjack/processor.rb
+++ b/lib/flapjack/processor.rb
@@ -226,7 +226,9 @@ module Flapjack
 
         entity_check.update_state(event.state, :timestamp => timestamp,
                                   :summary => event.summary, :count => event.counter,
-                                  :details => event.details, :perfdata => event.perfdata)
+                                  :details => event.details, :perfdata => event.perfdata,
+                                  :initial_failure_delay => event.initial_failure_delay,
+                                  :repeat_failure_delay => event.repeat_failure_delay)
 
         entity_check.update_current_scheduled_maintenance
 


### PR DESCRIPTION
This is a basic backport of `initial_failure_delay` and `repeat_failure_delay` from master into maint/1.x. Only the property defined on checks was backported; setting the property in the global configuration or on an entity is not currently supported.

I needed this for my environment, and I hope someone else finds it useful!