### PR TITLE
Use microsecond resolution for logs (maint/1.x)

### DIFF
--- a/lib/flapjack/logger.rb
+++ b/lib/flapjack/logger.rb
@@ -25,7 +25,7 @@ module Flapjack
       @name = name
 
       @formatter = proc do |severity, datetime, progname, msg|
-        t = datetime.iso8601
+        t = datetime.iso8601(6)
         "#{t} [#{severity}] :: #{name} :: #{msg}\n"
       end
 


### PR DESCRIPTION
Add microsecond resolution to ISO8601 time format in log messages, to help identify production performance bottlenecks.