### PR TITLE
Render an error message to the log when the api_url can't be connected to (closes #747)

### DIFF
--- a/lib/flapjack/gateways/web.rb
+++ b/lib/flapjack/gateways/web.rb
@@ -44,6 +44,7 @@ module Flapjack
           end
 
           @api_url = @config['api_url']
+          @api_connected = true
           if @api_url && URI.regexp(['http', 'https']).match(@api_url)
             unless @api_url.match(/^.*\/$/)
               Flapjack.logger.info "api_url must end with a trailing '/', setting to '#{@api_url}/'"
@@ -53,10 +54,14 @@ module Flapjack
             begin
               open(@api_url)
             rescue Errno::ECONNREFUSED => e
-              Flapjack.logger.error "Could not connect to api_url: (#{@api_url}): #{e.message}"
+              Flapjack.logger.warn "Could not connect to api_url: (#{@api_url}): #{e.message} - some functionality will be unavailable"
+              @api_connected = false
+            rescue OpenURI::HTTPError
+              # The API throws a 404 when hitting the front page.
             end
           else
-            Flapjack.logger.error "api_url not specified, or is not a valid http or https URI (#{@api_url})"
+            Flapjack.logger.warn "api_url not specified, or is not a valid http or https URI (#{@api_url}) - some functionality will be unavailable"
+            @api_connected = false
           end
 
           # constants won't be exposed to eRb scope

--- a/lib/flapjack/gateways/web.rb
+++ b/lib/flapjack/gateways/web.rb
@@ -55,13 +55,11 @@ module Flapjack
               open(@api_url)
             rescue Errno::ECONNREFUSED => e
               Flapjack.logger.warn "Could not connect to api_url: (#{@api_url}): #{e.message} - some functionality will be unavailable"
-              @api_connected = false
             rescue OpenURI::HTTPError
               # The API throws a 404 when hitting the front page.
             end
           else
             Flapjack.logger.warn "api_url not specified, or is not a valid http or https URI (#{@api_url}) - some functionality will be unavailable"
-            @api_connected = false
           end
 
           # constants won't be exposed to eRb scope

--- a/lib/flapjack/gateways/web/views/contacts.html.erb
+++ b/lib/flapjack/gateways/web/views/contacts.html.erb
@@ -19,7 +19,12 @@
   </table>
 <% end %>
 
-<a href="<%= @base_url %>edit_contacts"/>
-  Edit contacts
-  <span class="label label-danger">beta</span>
-</a>
+<% if @api_connected == true %>
+  <a href="<%= @base_url %>edit_contacts"/>
+    Edit contacts
+    <span class="label label-danger">beta</span>
+  </a>
+<% else %>
+  <span class="label label-warning">Could not connect to API URL - Edit contacts is unavailable"</span>
+<% end %>
+</div>

--- a/lib/flapjack/gateways/web/views/contacts.html.erb
+++ b/lib/flapjack/gateways/web/views/contacts.html.erb
@@ -19,12 +19,8 @@
   </table>
 <% end %>
 
-<% if @api_connected == true %>
-  <a href="<%= @base_url %>edit_contacts"/>
-    Edit contacts
-    <span class="label label-danger">beta</span>
-  </a>
-<% else %>
-  <span class="label label-warning">Could not connect to API URL - Edit contacts is unavailable"</span>
-<% end %>
+<a href="<%= @base_url %>edit_contacts"/>
+  Edit contacts
+  <span class="label label-danger">beta</span>
+</a>
 </div>


### PR DESCRIPTION
As we move more web functionality to call the web API, it seems like we want the web gateway to always fail if it can't connect.

This now shows:

```
2015-01-28T11:27:41.031525+11:00 [ERROR] :: flapjack-web :: api_url not specified, or is not a valid http or https URI (httz://localhost:3087/)

2015-01-28T11:26:12.244711+11:00 [ERROR] :: flapjack-web :: Could not connect to api_url: (http://localhost:3087/): Connection refused - connect(2) for "localhost" port 3087
```

This now also fails to start up the web UI.