### PR TITLE
bin/flapjack force stdout sync

### DIFF
--- a/bin/flapjack
+++ b/bin/flapjack
@@ -2,6 +2,8 @@
 
 require 'gli'
 
+$stdout.sync = true
+
 include GLI::App
 subcommand_option_handling :normal
 sort_help :manually


### PR DESCRIPTION
When starting flapjack from something like runit output appears to
be buffered extensively. By forcing sync it means that output is
available in real time in logs.

Primarily the advantage to using runit is that the service can be
automatically be restarted if/when it fails.