### PR TITLE
Fix for orphaned entity data

### DIFF
--- a/lib/flapjack/cli/import.rb
+++ b/lib/flapjack/cli/import.rb
@@ -65,6 +65,7 @@ module Flapjack
         return @redis unless @redis.nil?
         @redis = Redis.new(@redis_options.merge(:driver => :hiredis))
         Flapjack::Data::Migration.migrate_entity_check_data_if_required(:redis => @redis)
+        Flapjack::Data::Migration.clear_orphaned_entity_ids(:redis => @redis)
         @redis
       end
 

--- a/lib/flapjack/cli/maintenance.rb
+++ b/lib/flapjack/cli/maintenance.rb
@@ -68,6 +68,7 @@ module Flapjack
         return @redis unless @redis.nil?
         @redis = Redis.new(@redis_options.merge(:driver => :hiredis))
         Flapjack::Data::Migration.migrate_entity_check_data_if_required(:redis => @redis)
+        Flapjack::Data::Migration.clear_orphaned_entity_ids(:redis => @redis)
         Flapjack::Data::Migration.validate_scheduled_maintenance_periods(:redis => @redis)
         @redis
       end

--- a/lib/flapjack/cli/purge.rb
+++ b/lib/flapjack/cli/purge.rb
@@ -56,6 +56,7 @@ module Flapjack
         return @redis unless @redis.nil?
         @redis = Redis.new(@redis_options.merge(:driver => :hiredis))
         Flapjack::Data::Migration.migrate_entity_check_data_if_required(:redis => @redis)
+        Flapjack::Data::Migration.clear_orphaned_entity_ids(:redis => @redis)
         @redis
       end
 

--- a/lib/flapjack/cli/receiver.rb
+++ b/lib/flapjack/cli/receiver.rb
@@ -144,6 +144,7 @@ module Flapjack
         return @redis unless @redis.nil?
         @redis = Redis.new(@redis_options.merge(:driver => :hiredis))
         Flapjack::Data::Migration.migrate_entity_check_data_if_required(:redis => @redis)
+        Flapjack::Data::Migration.clear_orphaned_entity_ids(:redis => @redis)
         @redis
       end
 

--- a/lib/flapjack/cli/simulate.rb
+++ b/lib/flapjack/cli/simulate.rb
@@ -55,6 +55,7 @@ module Flapjack
         return @redis unless @redis.nil?
         @redis = Redis.new(@redis_options)
         Flapjack::Data::Migration.migrate_entity_check_data_if_required(:redis => @redis)
+        Flapjack::Data::Migration.clear_orphaned_entity_ids(:redis => @redis)
         @redis
       end
 

--- a/lib/flapjack/redis_pool.rb
+++ b/lib/flapjack/redis_pool.rb
@@ -27,6 +27,8 @@ module Flapjack
           :logger => logger)
         Flapjack::Data::Migration.create_entity_ids_if_required(:redis => redis,
           :logger => logger)
+        Flapjack::Data::Migration.clear_orphaned_entity_ids(:redis => redis,
+          :logger => logger)
         Flapjack::Data::Migration.refresh_archive_index(:redis => redis)
         Flapjack::Data::Migration.validate_scheduled_maintenance_periods(:redis => redis,
           :logger => logger)

--- a/spec/lib/flapjack/data/entity_spec.rb
+++ b/spec/lib/flapjack/data/entity_spec.rb
@@ -223,6 +223,8 @@ describe Flapjack::Data::Entity, :redis => true do
                                    :redis       => @redis)
     end
 
+    context 'check that rename and merge are called by add'
+
     context 'entity renaming on #add' do
 
       let(:time_i) { Time.now.to_i }
@@ -488,6 +490,19 @@ describe Flapjack::Data::Entity, :redis => true do
 
       before(:each) do
         add_name2
+      end
+
+      it 'clears the old id when a name exists' do
+        expect(@redis.hget('all_entity_ids_by_name', 'name2')).to eq('5000')
+        expect(@redis.hget('all_entity_names_by_id', '5000')).to eq('name2')
+
+        Flapjack::Data::Entity.add({'id'   => '5001',
+                                    'name' => 'name2'},
+                                    :redis => @redis)
+
+        expect(@redis.hget('all_entity_ids_by_name', 'name2')).to eq('5001')
+        expect(@redis.hget('all_entity_names_by_id', '5000')).to be_nil
+        expect(@redis.hget('all_entity_names_by_id', '5001')).to eq('name2')
       end
 
       it 'does not overwrite current state for a check' do

--- a/spec/lib/flapjack/data/migration_spec.rb
+++ b/spec/lib/flapjack/data/migration_spec.rb
@@ -4,6 +4,17 @@ require 'flapjack/data/notification_rule'
 
 describe Flapjack::Data::Migration, :redis => true do
 
+  it 'removes an orphaned entity id' do
+    @redis.hset('all_entity_ids_by_name', 'name_1', 'id_2')
+    @redis.hset('all_entity_names_by_id', 'id_1', 'name_1')
+    @redis.hset('all_entity_names_by_id', 'id_2', 'name_1')
+
+    Flapjack::Data::Migration.clear_orphaned_entity_ids(:redis => @redis)
+
+    expect(@redis.hgetall('all_entity_ids_by_name')).to eq('name_1' => 'id_2')
+    expect(@redis.hgetall('all_entity_names_by_id')).to eq('id_2' => 'name_1')
+  end
+
   it "fixes a notification rule wih no contact association" do
     contact = Flapjack::Data::Contact.add( {
         'id'         => 'c362',

--- a/spec/lib/flapjack/redis_pool_spec.rb
+++ b/spec/lib/flapjack/redis_pool_spec.rb
@@ -15,6 +15,7 @@ describe Flapjack::RedisPool do
       expect(Flapjack::Data::Migration).to receive(:correct_notification_rule_contact_linkages).exactly(redis_count).times
       expect(Flapjack::Data::Migration).to receive(:migrate_entity_check_data_if_required).exactly(redis_count).times
       expect(Flapjack::Data::Migration).to receive(:create_entity_ids_if_required).exactly(redis_count).times
+      expect(Flapjack::Data::Migration).to receive(:clear_orphaned_entity_ids).exactly(redis_count).times
       expect(Flapjack::Data::Migration).to receive(:refresh_archive_index).exactly(redis_count).times
       expect(Flapjack::Data::Migration).to receive(:validate_scheduled_maintenance_periods).exactly(redis_count).times
 


### PR DESCRIPTION
When entity data with the same name but different ids comes in, old keys were being left in the index we keep. This fixes the bug and also has a data migration to clean up any data left in such a state.

@jessereynolds , I'd appreciate it if you could try to think of any dangers I may have missed.