### PR TITLE
don't exit_now! for signalled shutdown

### DIFF
--- a/lib/flapjack/cli/server.rb
+++ b/lib/flapjack/cli/server.rb
@@ -60,7 +60,10 @@ module Flapjack
             return_value = start_server
           }
           puts " done."
-          exit_now!(return_value) unless return_value.nil?
+          unless return_value.nil? || [Signal.list['INT'] + 128,
+                                       Signal.list['TERM'] + 128].include?(return_value)
+            exit_now!(return_value)
+          end
         end
       end
 

--- a/lib/flapjack/coordinator.rb
+++ b/lib/flapjack/coordinator.rb
@@ -43,7 +43,7 @@ module Flapjack
           loop do
             while sig = @received_signals.shift do
               case sig
-              when 'INT', 'TERM', 'QUIT'
+              when 'INT', 'TERM'
                 @exit_value = Signal.list[sig] + 128
                 raise Interrupt
               when 'HUP'
@@ -127,7 +127,6 @@ module Flapjack
       Kernel.trap('INT')    { @received_signals << 'INT' unless @received_signals.include?('INT') }
       Kernel.trap('TERM')   { @received_signals << 'TERM' unless @received_signals.include?('TERM') }
       unless RbConfig::CONFIG['host_os'] =~ /mswin|windows|cygwin/i
-        Kernel.trap('QUIT') { @received_signals << 'QUIT' unless @received_signals.include?('QUIT') }
         Kernel.trap('HUP')  { @received_signals << 'HUP' unless @received_signals.include?('HUP') }
       end
     end

--- a/spec/lib/flapjack/coordinator_spec.rb
+++ b/spec/lib/flapjack/coordinator_spec.rb
@@ -171,7 +171,6 @@ describe Flapjack::Coordinator do
 
     expect(Kernel).to receive(:trap).with('INT').and_yield
     expect(Kernel).to receive(:trap).with('TERM').and_yield
-    expect(Kernel).to receive(:trap).with('QUIT').and_yield
     expect(Kernel).to receive(:trap).with('HUP').and_yield
 
     expect(config).to receive(:all).and_return({})
@@ -179,7 +178,7 @@ describe Flapjack::Coordinator do
     fc = Flapjack::Coordinator.new(config)
 
     fc.send(:setup_signals)
-    expect(fc.instance_variable_get('@received_signals')).to eq(['INT', 'TERM', 'QUIT', 'HUP'])
+    expect(fc.instance_variable_get('@received_signals')).to eq(['INT', 'TERM', 'HUP'])
   end
 
   it "only traps two system signals on Windows" do
@@ -189,7 +188,6 @@ describe Flapjack::Coordinator do
 
     expect(Kernel).to receive(:trap).with('INT').and_yield
     expect(Kernel).to receive(:trap).with('TERM').and_yield
-    expect(Kernel).not_to receive(:trap).with('QUIT')
     expect(Kernel).not_to receive(:trap).with('HUP')
 
     expect(config).to receive(:all).and_return({})


### PR DESCRIPTION
Also removes the QUIT signal, as it doesn't work in Windows runtimes or under the JVM.