### PR TITLE
Try to fix encoding exceptions

### DIFF
--- a/bin/flapjack
+++ b/bin/flapjack
@@ -14,14 +14,19 @@ program_desc 'Flexible monitoring notification routing system'
 version Flapjack::VERSION
 
 desc 'Configuration file to use'
-default_value '/etc/flapjack/flapjack_config.yaml'
-arg_name '/path/to/flapjack.yaml'
-flag [:c,:config]
+flag [:c,:config],
+  :arg_name => '/path/to/flapjack.yaml',
+  :default_value => '/etc/flapjack/flapjack_config.yaml'
 
 desc 'Environment to boot'
-default_value 'production'
-arg_name '<environment>'
-flag [:n, :env, :environment]
+flag [:n, :env, :environment],
+  :arg_name => '<environment>',
+  :default_value => 'production'
+
+desc 'Force UTF-8 encoding'
+switch [:'force-utf8'],
+  :negatable => true,
+  :default_value => true
 
 accept Array do |value|
   value.split(/,/).map(&:strip)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-#
+
+Encoding.default_internal = 'UTF-8'
 
 require 'delorean'
 require 'chronic'

--- a/lib/flapjack.rb
+++ b/lib/flapjack.rb
@@ -15,5 +15,11 @@ module Flapjack
     Oj.dump(data, :mode => :compat, :time_format => :ruby, :indent => 0)
   end
 
+  def self.sanitize(str)
+    return str if str.nil? || !str.is_a?(String) || str.valid_encoding?
+    return str.scrub('?') if str.respond_to(:scrub)
+    str.chars.collect {|c| c.valid_encoding? ? c : '_' }.join
+  end
+
 end
 

--- a/lib/flapjack/cli/flapper.rb
+++ b/lib/flapjack/cli/flapper.rb
@@ -28,6 +28,11 @@ module Flapjack
         @global_options = global_options
         @options = options
 
+        if @global_options[:'force-utf8']
+          Encoding.default_external = 'UTF-8'
+          Encoding.default_internal = 'UTF-8'
+        end
+
         @config = Flapjack::Configuration.new
         @config.load(global_options[:config])
         @config_env = @config.all

--- a/lib/flapjack/cli/import.rb
+++ b/lib/flapjack/cli/import.rb
@@ -15,6 +15,11 @@ module Flapjack
         @global_options = global_options
         @options = options
 
+        if @global_options[:'force-utf8']
+          Encoding.default_external = 'UTF-8'
+          Encoding.default_internal = 'UTF-8'
+        end
+
         config = Flapjack::Configuration.new
         config.load(global_options[:config])
         @config_env = config.all

--- a/lib/flapjack/cli/maintenance.rb
+++ b/lib/flapjack/cli/maintenance.rb
@@ -17,6 +17,11 @@ module Flapjack
         @global_options = global_options
         @options = options
 
+        if @global_options[:'force-utf8']
+          Encoding.default_external = 'UTF-8'
+          Encoding.default_internal = 'UTF-8'
+        end
+
         config = Flapjack::Configuration.new
         config.load(global_options[:config])
         @config_env = config.all

--- a/lib/flapjack/cli/purge.rb
+++ b/lib/flapjack/cli/purge.rb
@@ -13,6 +13,11 @@ module Flapjack
         @global_options = global_options
         @options = options
 
+        if @global_options[:'force-utf8']
+          Encoding.default_external = 'UTF-8'
+          Encoding.default_internal = 'UTF-8'
+        end
+
         config = Flapjack::Configuration.new
         config.load(global_options[:config])
         @config_env = config.all

--- a/lib/flapjack/cli/receiver.rb
+++ b/lib/flapjack/cli/receiver.rb
@@ -19,6 +19,11 @@ module Flapjack
         @global_options = global_options
         @options = options
 
+        if @global_options[:'force-utf8']
+          Encoding.default_external = 'UTF-8'
+          Encoding.default_internal = 'UTF-8'
+        end
+
         @config = Flapjack::Configuration.new
         @config.load(global_options[:config])
         @config_env = @config.all

--- a/lib/flapjack/cli/server.rb
+++ b/lib/flapjack/cli/server.rb
@@ -12,6 +12,11 @@ module Flapjack
         @global_options = global_options
         @options = options
 
+        if @global_options[:'force-utf8']
+          Encoding.default_external = 'UTF-8'
+          Encoding.default_internal = 'UTF-8'
+        end
+
         @config = Flapjack::Configuration.new
         @config.load(global_options[:config])
         @config_env = @config.all

--- a/lib/flapjack/cli/simulate.rb
+++ b/lib/flapjack/cli/simulate.rb
@@ -17,6 +17,11 @@ module Flapjack
         @global_options = global_options
         @options = options
 
+        if @global_options[:'force-utf8']
+          Encoding.default_external = 'UTF-8'
+          Encoding.default_internal = 'UTF-8'
+        end
+
         config = Flapjack::Configuration.new
         config.load(global_options[:config])
         @config_env = config.all

--- a/lib/flapjack/data/contact.rb
+++ b/lib/flapjack/data/contact.rb
@@ -103,8 +103,10 @@ module Flapjack
       # TODO may want to make this protected/private, it's only
       # used in this class
       def refresh
-        self.first_name, self.last_name, self.email =
-          @redis.hmget("contact:#{@id}", 'first_name', 'last_name', 'email')
+        fn, ln, em = @redis.hmget("contact:#{@id}", 'first_name', 'last_name', 'email')
+        self.first_name = Flapjack.sanitize(fn)
+        self.last_name  = Flapjack.sanitize(ln)
+        self.email      = Flapjack.sanitize(em)
         self.media = @redis.hgetall("contact_media:#{@id}")
         self.media_intervals = @redis.hgetall("contact_media_intervals:#{self.id}")
         self.media_rollup_thresholds = @redis.hgetall("contact_media_rollup_thresholds:#{self.id}")

--- a/lib/flapjack/data/entity_check.rb
+++ b/lib/flapjack/data/entity_check.rb
@@ -1000,8 +1000,8 @@ module Flapjack
 
       def initialize(entity, check, options = {})
         raise "Redis connection not set" unless @redis = options[:redis]
-        raise "Invalid entity (#{entity.inspect})" unless @entity = entity
-        raise "Invalid check (#{check.inspect} on #{entity.inspect})" unless @check = check
+        raise "Invalid entity (#{entity.inspect})" unless @entity = Flapjack.sanitize(entity)
+        raise "Invalid check (#{check.inspect} on #{entity.inspect})" unless @check = Flapjack.sanitize(check)
         @key = "#{entity.name}:#{check}"
         if @redis.zscore("all_checks", @key).nil?
           timestamp = options[:timestamp] || Time.now.to_i

--- a/lib/flapjack/data/event.rb
+++ b/lib/flapjack/data/event.rb
@@ -234,7 +234,8 @@ module Flapjack
         ['type', 'state', 'entity', 'check', 'time', 'summary', 'details',
          'perfdata', 'acknowledgement_id', 'duration', 'initial_failure_delay',
          'repeat_failure_delay'].each do |key|
-          instance_variable_set("@#{key}", attrs[key])
+
+          instance_variable_set("@#{key}", Flapjack.sanitize(attrs[key]))
         end
         # summary is optional. set it to nil if it only contains whitespace
         @summary = (@summary.is_a?(String) && ! @summary.strip.empty?) ? @summary.strip : nil

--- a/lib/flapjack/gateways/aws_sns.rb
+++ b/lib/flapjack/gateways/aws_sns.rb
@@ -66,23 +66,18 @@ module Flapjack
         notification_id = alert.notification_id
         message_type    = alert.rollup ? 'rollup' : 'alert'
 
-        my_dir = File.dirname(__FILE__)
-        sms_template_path = case
-        when @config.has_key?('templates') && @config['templates']["#{message_type}.text"]
-          @config['templates']["#{message_type}.text"]
-        else
-          my_dir + "/aws_sns/#{message_type}.text.erb"
-        end
-        sms_template = ERB.new(File.read(sms_template_path), nil, '-')
+        sms_template_erb, sms_template =
+          load_template(@config['templates'], message_type, 'text',
+                        File.join(File.dirname(__FILE__), 'aws_sns'))
 
         @alert  = alert
         bnd     = binding
 
         begin
-          message = sms_template.result(bnd).chomp
+          message = sms_template_erb.result(bnd).chomp
         rescue => e
-          @logger.error "Error while excuting the ERB for an sms: " +
-            "ERB being executed: #{sms_template_path}"
+          @logger.error "Error while executing the ERB for an sms: " +
+            "ERB being executed: #{sms_template}"
           raise
         end
 

--- a/lib/flapjack/gateways/jabber.rb
+++ b/lib/flapjack/gateways/jabber.rb
@@ -784,23 +784,18 @@ module Flapjack
 
             message_type = alert.rollup ? 'rollup' : 'alert'
 
-            mydir = File.dirname(__FILE__)
-            message_template_path = case
-            when @config.has_key?('templates') && @config['templates']["#{message_type}.text"]
-              @config['templates']["#{message_type}.text"]
-            else
-              mydir + "/jabber/#{message_type}.text.erb"
-            end
-            message_template = ERB.new(File.read(message_template_path), nil, '-')
+            message_template_erb, message_template =
+              load_template(@config['templates'], message_type,
+                            'text', File.join(File.dirname(__FILE__), 'jabber'))
 
             @alert = alert
             bnd    = binding
 
             begin
-              message = message_template.result(bnd).chomp
+              message = message_template_erb.result(bnd).chomp
             rescue => e
-              @logger.error "Error while excuting the ERB for a jabber message, " +
-                "ERB being executed: #{message_template_path}"
+              @logger.error "Error while executing the ERB for a jabber message, " +
+                "ERB being executed: #{message_template}"
               raise
             end
 

--- a/lib/flapjack/gateways/jabber.rb
+++ b/lib/flapjack/gateways/jabber.rb
@@ -24,7 +24,6 @@ module Flapjack
       log.level = ::Logger::INFO
       Blather.logger = log
 
-      # TODO if we use 'xmpp4r' rather than 'blather', port this to 'rexml'
       class TextHandler < Nokogiri::XML::SAX::Document
         def initialize
           @chunks = []
@@ -131,7 +130,7 @@ module Flapjack
             presence << "<x xmlns='http://jabber.org/protocol/muc'><history maxstanzas='0'></x>"
             EventMachine::Synchrony.next_tick do
               write presence
-              say(room, "flapjack jabber gateway started at #{Time.now}, hello! Try typing 'help'.", :groupchat)
+              say(room, "flapjack's jabber gateway started at #{Time.now}, hello! Try typing 'help'.", :groupchat)
             end
           end
         end

--- a/lib/flapjack/gateways/pagerduty.rb
+++ b/lib/flapjack/gateways/pagerduty.rb
@@ -77,23 +77,18 @@ module Flapjack
             @logger.debug("processing pagerduty notification service_key: #{alert.address}, entity: #{alert.entity}, " +
                           "check: '#{alert.check}', state: #{alert.state}, summary: #{alert.summary}")
 
-            mydir = File.dirname(__FILE__)
-            message_template_path = case
-            when @config.has_key?('templates') && @config['templates']['alert.text']
-              @config['templates']['alert.text']
-            else
-              mydir + "/pagerduty/alert.text.erb"
-            end
-            message_template = ERB.new(File.read(message_template_path), nil, '-')
+            message_template_erb, message_template =
+              load_template(@config['templates'], 'alert',
+                            'text', File.join(File.dirname(__FILE__), 'pagerduty'))
 
             @alert = alert
             bnd    = binding
 
             begin
-              message = message_template.result(bnd).chomp
+              message = message_template_erb.result(bnd).chomp
             rescue => e
-              @logger.error "Error while excuting the ERB for a pagerduty message, " +
-                "ERB being executed: #{message_template_path}"
+              @logger.error "Error while executing the ERB for a pagerduty message, " +
+                "ERB being executed: #{message_template}"
               raise
             end
 

--- a/lib/flapjack/gateways/sms_messagenet.rb
+++ b/lib/flapjack/gateways/sms_messagenet.rb
@@ -63,23 +63,18 @@ module Flapjack
         notification_id = alert.notification_id
         message_type    = alert.rollup ? 'rollup' : 'alert'
 
-        my_dir = File.dirname(__FILE__)
-        sms_template_path = case
-        when @config.has_key?('templates') && @config['templates']["#{message_type}.text"]
-          @config['templates']["#{message_type}.text"]
-        else
-          my_dir + "/sms_messagenet/#{message_type}.text.erb"
-        end
-        sms_template = ERB.new(File.read(sms_template_path), nil, '-')
+        sms_template_erb, sms_template =
+          load_template(@config['templates'], message_type, 'text',
+                        File.join(File.dirname(__FILE__), 'sms_messagenet'))
 
         @alert  = alert
         bnd     = binding
 
         begin
-          message = sms_template.result(bnd).chomp
+          message = sms_template_erb.result(bnd).chomp
         rescue => e
-          @logger.error "Error while excuting the ERB for an sms: " +
-            "ERB being executed: #{sms_template_path}"
+          @logger.error "Error while executing the ERB for an sms: " +
+            "ERB being executed: #{sms_template}"
           raise
         end
 

--- a/lib/flapjack/gateways/sms_nexmo.rb
+++ b/lib/flapjack/gateways/sms_nexmo.rb
@@ -63,23 +63,18 @@ module Flapjack
         notification_id = alert.notification_id
         message_type    = alert.rollup ? 'rollup' : 'alert'
 
-        my_dir = File.dirname(__FILE__)
-        sms_template_path = case
-        when @config.has_key?('templates') && @config['templates']["#{message_type}.text"]
-          @config['templates']["#{message_type}.text"]
-        else
-          my_dir + "/sms_nexmo/#{message_type}.text.erb"
-        end
-        sms_template = ERB.new(File.read(sms_template_path), nil, '-')
+        sms_template_erb, sms_template =
+          load_template(@config['templates'], message_type, 'text',
+                        File.join(File.dirname(__FILE__), 'sms_nexmo'))
 
         @alert  = alert
         bnd     = binding
 
         begin
-          message = sms_template.result(bnd).chomp
+          message = sms_template_erb.result(bnd).chomp
         rescue => e
-          @logger.error "Error while excuting the ERB for an sms: " +
-            "ERB being executed: #{sms_template_path}"
+          @logger.error "Error while executing the ERB for an sms: " +
+            "ERB being executed: #{sms_template}"
           raise
         end
 

--- a/lib/flapjack/gateways/sms_twilio.rb
+++ b/lib/flapjack/gateways/sms_twilio.rb
@@ -68,23 +68,18 @@ module Flapjack
         notification_id = alert.notification_id
         message_type    = alert.rollup ? 'rollup' : 'alert'
 
-        my_dir = File.dirname(__FILE__)
-        sms_template_path = case
-        when @config.has_key?('templates') && @config['templates']["#{message_type}.text"]
-          @config['templates']["#{message_type}.text"]
-        else
-          my_dir + "/sms_twilio/#{message_type}.text.erb"
-        end
-        sms_template = ERB.new(File.read(sms_template_path), nil, '-')
+        sms_template_erb, sms_template =
+          load_template(@config['templates'], message_type, 'text',
+                        File.join(File.dirname(__FILE__), 'sms_twilio'))
 
         @alert  = alert
         bnd     = binding
 
         begin
-          message = sms_template.result(bnd).chomp
+          message = sms_template_erb.result(bnd).chomp
         rescue => e
-          @logger.error "Error while excuting the ERB for an sms: " +
-            "ERB being executed: #{sms_template_path}"
+          @logger.error "Error while executing the ERB for an sms: " +
+            "ERB being executed: #{sms_template}"
           raise
         end
 

--- a/lib/flapjack/gateways/web.rb
+++ b/lib/flapjack/gateways/web.rb
@@ -119,6 +119,11 @@ module Flapjack
         def include_active?(path)
           request.path == "/#{path}" ? " class='active'" : ""
         end
+
+        def charset_for_content_type(ct)
+          charset = Encoding.default_external
+          charset.nil? ? ct : "#{ct}; charset=#{charset}"
+        end
       end
 
       def redis
@@ -130,6 +135,8 @@ module Flapjack
       end
 
       before do
+        content_type charset_for_content_type('text/html')
+
         @api_url          = self.class.instance_variable_get('@api_url')
         @base_url         = self.class.instance_variable_get('@base_url')
         @default_logo_url = self.class.instance_variable_get('@default_logo_url')

--- a/lib/flapjack/utility.rb
+++ b/lib/flapjack/utility.rb
@@ -81,6 +81,20 @@ module Flapjack
       (text.length > length ? text[0...stop] + options[:omission] : text).to_s
     end
 
+    def load_template(template_config, message_type, message_filetype,
+                      default_template_path)
+      template_file = if template_config.nil? || !template_config.has_key?("#{message_type}.#{message_filetype}")
+        # we ship UTF-8 templates with the gem
+        template_path = File.join(default_template_path, "#{message_type}.#{message_filetype}.erb")
+        File.open(template_path, "r:UTF-8", &:read)
+      else
+         # respects Encoding.default_external (UTF-8 or ENV['LANG'])
+        template_path = template_config["#{message_type}.#{message_filetype}"]
+        File.read(template_path)
+      end
+      [ERB.new(template_file, nil, '-'), template_file]
+    end
+
     private
 
     def plural_s(value)

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -5,8 +5,6 @@ require 'flapjack/gateways/jsonapi'
 
 require './spec/service_consumers/provider_states_for_flapjack-diner.rb'
 
-$testing = true
-
 FLAPJACK_ENV    = ENV["FLAPJACK_ENV"] || 'test'
 FLAPJACK_ROOT   = File.join(File.dirname(__FILE__), '..')
 FLAPJACK_CONFIG = File.join(FLAPJACK_ROOT, 'etc', 'flapjack_config.yaml')

--- a/spec/service_consumers/pacts/flapjack-diner_v1.0.json
+++ b/spec/service_consumers/pacts/flapjack-diner_v1.0.json
@@ -7,146 +7,279 @@
   },
   "interactions": [
     {
-      "description": "a time limited GET request for a outage report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
+      "description": "a GET request for one set of pagerduty credentials",
+      "provider_state": "a contact with id 'abc' has pagerduty credentials",
       "request": {
         "method": "get",
-        "path": "/outage_report/entities/1234",
-        "query": "start_time=2014-12-02T10%3A31%3A27%2B10%3A30&end_time=2014-12-02T22%3A31%3A27%2B10%3A30"
+        "path": "/pagerduty_credentials/abc"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
-          "outage_reports": [
+          "pagerduty_credentials": [
             {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
+              "service_key": "abc",
+              "subdomain": "def",
+              "username": "ghi",
+              "password": "jkl"
             }
           ]
         }
       }
     },
     {
-      "description": "a GET request for a downtime report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
+      "description": "a GET request for all pagerduty credentials",
+      "provider_state": "a contact with id 'abc' has pagerduty credentials",
       "request": {
         "method": "get",
-        "path": "/downtime_report/entities"
+        "path": "/pagerduty_credentials"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
-          "downtime_reports": [
+          "pagerduty_credentials": [
             {
+              "service_key": "abc",
+              "subdomain": "def",
+              "username": "ghi",
+              "password": "jkl"
             }
           ]
         }
       }
     },
     {
-      "description": "a GET request for a status report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
+      "description": "a GET request for two sets of pagerduty credentials",
+      "provider_state": "contacts with ids 'abc' and '872' have pagerduty credentials",
       "request": {
         "method": "get",
-        "path": "/status_report/entities"
+        "path": "/pagerduty_credentials/abc,872"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
-          "status_reports": [
+          "pagerduty_credentials": [
             {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a downtime report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/entities/1234"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a downtime report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/entities/1234,5678"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
+              "service_key": "abc",
+              "subdomain": "def",
+              "username": "ghi",
+              "password": "jkl"
             },
             {
+              "service_key": "mno",
+              "subdomain": "pqr",
+              "username": "stu",
+              "password": "vwx"
             }
           ]
         }
       }
     },
     {
-      "description": "a GET request for a outage report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
+      "description": "a GET request for one set of pagerduty credentials",
+      "provider_state": "no contact exists",
       "request": {
         "method": "get",
-        "path": "/outage_report/entities/1234"
+        "path": "/pagerduty_credentials/abc"
       },
       "response": {
-        "status": 200,
+        "status": 404,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
-          "outage_reports": [
+          "errors": [
+            "could not find contact 'abc'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a POST request with one set of pagerduty credentials",
+      "provider_state": "a contact with id 'abc' exists",
+      "request": {
+        "method": "post",
+        "path": "/contacts/abc/pagerduty_credentials",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "pagerduty_credentials": [
             {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
+              "service_key": "abc",
+              "subdomain": "def",
+              "username": "ghi",
+              "password": "jkl"
             }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": [
+          "abc"
+        ]
+      }
+    },
+    {
+      "description": "a POST request with one set of pagerduty credentials",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "post",
+        "path": "/contacts/abc/pagerduty_credentials",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "pagerduty_credentials": [
+            {
+              "service_key": "abc",
+              "subdomain": "def",
+              "username": "ghi",
+              "password": "jkl"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 422,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "errors": [
+            "Contact id: 'abc' could not be loaded"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a PATCH request for pagerduty credentials",
+      "provider_state": "contacts with ids 'abc' and '872' have pagerduty credentials",
+      "request": {
+        "method": "patch",
+        "path": "/pagerduty_credentials/abc,872",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/pagerduty_credentials/0/password",
+            "value": "pswrd"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for pagerduty credentials",
+      "provider_state": "a contact with id 'abc' has pagerduty credentials",
+      "request": {
+        "method": "patch",
+        "path": "/pagerduty_credentials/abc",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/pagerduty_credentials/0/password",
+            "value": "pswrd"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for pagerduty credentials",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "patch",
+        "path": "/pagerduty_credentials/abc",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/pagerduty_credentials/0/password",
+            "value": "pswrd"
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contact 'abc'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a DELETE request for two sets of pagerduty credentials",
+      "provider_state": "contacts with ids 'abc' and '872' have pagerduty credentials",
+      "request": {
+        "method": "delete",
+        "path": "/pagerduty_credentials/abc,872",
+        "body": null
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for one set of pagerduty credentials",
+      "provider_state": "a contact with id 'abc' has pagerduty credentials",
+      "request": {
+        "method": "delete",
+        "path": "/pagerduty_credentials/abc",
+        "body": null
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for one set of pagerduty credentials",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "delete",
+        "path": "/pagerduty_credentials/abc",
+        "body": null
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contact 'abc'"
           ]
         }
       }
@@ -157,12 +290,12 @@
       "request": {
         "method": "get",
         "path": "/downtime_report/entities",
-        "query": "start_time=2014-12-02T10%3A31%3A27%2B10%3A30&end_time=2014-12-02T22%3A31%3A27%2B10%3A30"
+        "query": "start_time=2015-03-02T14%3A22%3A50%2B10%3A30&end_time=2015-03-03T02%3A22%3A50%2B10%3A30"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "downtime_reports": [
@@ -173,21 +306,43 @@
       }
     },
     {
-      "description": "a GET request for a scheduled_maintenance report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
+      "description": "a GET request for a status report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
       "request": {
         "method": "get",
-        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH"
+        "path": "/status_report/checks/www.example.com:SSH,www2.example.com:PING"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
-          "scheduled_maintenance_reports": [
+          "status_reports": [
             {
-              "scheduled_maintenances": [
+            },
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a unscheduled_maintenance report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/checks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
 
               ],
               "links": {
@@ -209,50 +364,18 @@
       "request": {
         "method": "get",
         "path": "/downtime_report/checks/www.example.com:SSH,www2.example.com:PING",
-        "query": "start_time=2014-12-02T10%3A31%3A27%2B10%3A30&end_time=2014-12-02T22%3A31%3A27%2B10%3A30"
+        "query": "start_time=2015-03-02T14%3A22%3A50%2B10%3A30&end_time=2015-03-03T02%3A22%3A50%2B10%3A30"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "downtime_reports": [
             {
             },
             {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a outage report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/checks",
-        "query": "start_time=2014-12-02T10%3A31%3A27%2B10%3A30&end_time=2014-12-02T22%3A31%3A27%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
             }
           ]
         }
@@ -268,7 +391,7 @@
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "scheduled_maintenance_reports": [
@@ -290,16 +413,17 @@
       }
     },
     {
-      "description": "a GET request for a outage report on two checks",
+      "description": "a time limited GET request for a outage report on two entities",
       "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
       "request": {
         "method": "get",
-        "path": "/outage_report/checks/www.example.com:SSH,www2.example.com:PING"
+        "path": "/outage_report/entities/1234,5678",
+        "query": "start_time=2015-03-02T14%3A22%3A50%2B10%3A30&end_time=2015-03-03T02%3A22%3A50%2B10%3A30"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "outage_reports": [
@@ -339,12 +463,12 @@
       "request": {
         "method": "get",
         "path": "/downtime_report/checks/www.example.com:SSH",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
+        "query": "start_time=2015-03-02T14%3A22%3A50%2B10%3A30&end_time=2015-03-03T02%3A22%3A50%2B10%3A30"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "downtime_reports": [
@@ -355,271 +479,16 @@
       }
     },
     {
-      "description": "a GET request for a unscheduled_maintenance report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a scheduled_maintenance report on all checks",
+      "description": "a GET request for a outage report on all checks",
       "provider_state": "a check 'www.example.com:SSH' exists",
       "request": {
         "method": "get",
-        "path": "/scheduled_maintenance_report/checks"
+        "path": "/outage_report/checks"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a unscheduled_maintenance report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/entities/1234"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a scheduled_maintenance report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/checks",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a status report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/status_report/checks/www.example.com:SSH,www2.example.com:PING"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "status_reports": [
-            {
-            },
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a unscheduled_maintenance report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/checks/www.example.com:SSH",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a unscheduled_maintenance report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/entities"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a unscheduled_maintenance report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/entities",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a outage report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/entities"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "outage_reports": [
@@ -635,416 +504,6 @@
                   "www.example.com:SSH"
                 ]
               }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a status report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/status_report/checks/www.example.com:SSH"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "status_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time-limited GET request for a scheduled_maintenance report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a status report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/status_report/entities/1234,5678"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "status_reports": [
-            {
-            },
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a scheduled_maintenance report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/entities/1234,5678"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a scheduled_maintenance report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/entities",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a status report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/status_report/entities/1234"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "status_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a outage report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/entities",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a downtime report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/checks/www.example.com:SSH"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a unscheduled_maintenance report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/entities/1234,5678",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a scheduled_maintenance report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a outage report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/checks/www.example.com:SSH",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a scheduled_maintenance report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/entities/1234",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a downtime report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/checks/www.example.com:SSH,www2.example.com:PING"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            },
-            {
             }
           ]
         }
@@ -1060,43 +519,12 @@
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "outage_reports": [
             {
               "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a unscheduled_maintenance report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/checks"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
 
               ],
               "links": {
@@ -1118,333 +546,12 @@
       "request": {
         "method": "get",
         "path": "/outage_report/checks/www.example.com:SSH,www2.example.com:PING",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
+        "query": "start_time=2015-03-02T14%3A22%3A50%2B10%3A30&end_time=2015-03-03T02%3A22%3A50%2B10%3A30"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a outage report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/checks"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a scheduled_maintenance report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a unscheduled_maintenance report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/checks",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a downtime report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/checks",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a downtime report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/checks"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a outage report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/entities/1234,5678",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a scheduled_maintenance report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/entities/1234,5678",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a status report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/status_report/checks"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "status_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a scheduled_maintenance report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/entities/1234"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a outage report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/entities/1234,5678"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "outage_reports": [
@@ -1488,7 +595,7 @@
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "unscheduled_maintenance_reports": [
@@ -1504,61 +611,6 @@
                   "www.example.com:SSH"
                 ]
               }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a unscheduled_maintenance report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/entities/1234",
-        "query": "start_time=2014-12-02T10%3A31%3A29%2B10%3A30&end_time=2014-12-02T22%3A31%3A29%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a downtime report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/entities/1234,5678",
-        "query": "start_time=2014-12-02T10%3A31%3A29%2B10%3A30&end_time=2014-12-02T22%3A31%3A29%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            },
-            {
             }
           ]
         }
@@ -1570,12 +622,12 @@
       "request": {
         "method": "get",
         "path": "/unscheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING",
-        "query": "start_time=2014-12-02T10%3A31%3A29%2B10%3A30&end_time=2014-12-02T22%3A31%3A29%2B10%3A30"
+        "query": "start_time=2015-03-02T14%3A22%3A50%2B10%3A30&end_time=2015-03-03T02%3A22%3A50%2B10%3A30"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "unscheduled_maintenance_reports": [
@@ -1604,6 +656,657 @@
                   "www2.example.com:PING"
                 ]
               }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a scheduled_maintenance report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/entities/1234"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a unscheduled_maintenance report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/entities/1234,5678",
+        "query": "start_time=2015-03-02T14%3A22%3A50%2B10%3A30&end_time=2015-03-03T02%3A22%3A50%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a scheduled_maintenance report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/entities",
+        "query": "start_time=2015-03-02T14%3A22%3A50%2B10%3A30&end_time=2015-03-03T02%3A22%3A50%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a downtime report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/checks/www.example.com:SSH"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a outage report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/entities/1234"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a scheduled_maintenance report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH",
+        "query": "start_time=2015-03-02T14%3A22%3A50%2B10%3A30&end_time=2015-03-03T02%3A22%3A50%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a downtime report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/checks",
+        "query": "start_time=2015-03-02T14%3A22%3A50%2B10%3A30&end_time=2015-03-03T02%3A22%3A50%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a status report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/status_report/checks/www.example.com:SSH"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "status_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a scheduled_maintenance report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/entities/1234,5678"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a status report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/status_report/checks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "status_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a unscheduled_maintenance report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/checks/www.example.com:SSH",
+        "query": "start_time=2015-03-02T14%3A22%3A50%2B10%3A30&end_time=2015-03-03T02%3A22%3A50%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a downtime report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/entities"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a status report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/status_report/entities/1234"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "status_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a scheduled_maintenance report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time-limited GET request for a scheduled_maintenance report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING",
+        "query": "start_time=2015-03-02T14%3A22%3A51%2B10%3A30&end_time=2015-03-03T02%3A22%3A51%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a outage report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/checks/www.example.com:SSH,www2.example.com:PING"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a downtime report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/entities/1234,5678",
+        "query": "start_time=2015-03-02T14%3A22%3A51%2B10%3A30&end_time=2015-03-03T02%3A22%3A51%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            },
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a downtime report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/entities/1234"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a downtime report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/entities/1234",
+        "query": "start_time=2015-03-02T14%3A22%3A51%2B10%3A30&end_time=2015-03-03T02%3A22%3A51%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a unscheduled_maintenance report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/checks",
+        "query": "start_time=2015-03-02T14%3A22%3A51%2B10%3A30&end_time=2015-03-03T02%3A22%3A51%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a outage report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/checks/www.example.com:SSH",
+        "query": "start_time=2015-03-02T14%3A22%3A51%2B10%3A30&end_time=2015-03-03T02%3A22%3A51%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a downtime report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/entities/1234,5678"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            },
+            {
             }
           ]
         }
@@ -1619,7 +1322,7 @@
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "unscheduled_maintenance_reports": [
@@ -1654,17 +1357,454 @@
       }
     },
     {
-      "description": "a time limited GET request for a downtime report on one entity",
+      "description": "a time limited GET request for a unscheduled_maintenance report on one entity",
       "provider_state": "a check 'www.example.com:SSH' exists",
       "request": {
         "method": "get",
-        "path": "/downtime_report/entities/1234",
-        "query": "start_time=2014-12-02T10%3A31%3A29%2B10%3A30&end_time=2014-12-02T22%3A31%3A29%2B10%3A30"
+        "path": "/unscheduled_maintenance_report/entities/1234",
+        "query": "start_time=2015-03-02T14%3A22%3A51%2B10%3A30&end_time=2015-03-03T02%3A22%3A51%2B10%3A30"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a outage report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/entities",
+        "query": "start_time=2015-03-02T14%3A22%3A51%2B10%3A30&end_time=2015-03-03T02%3A22%3A51%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a scheduled_maintenance report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a unscheduled_maintenance report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/entities",
+        "query": "start_time=2015-03-02T14%3A22%3A51%2B10%3A30&end_time=2015-03-03T02%3A22%3A51%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a scheduled_maintenance report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/checks",
+        "query": "start_time=2015-03-02T14%3A22%3A51%2B10%3A30&end_time=2015-03-03T02%3A22%3A51%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a unscheduled_maintenance report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/entities/1234"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a outage report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/entities/1234,5678"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a scheduled_maintenance report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/checks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a downtime report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/checks/www.example.com:SSH,www2.example.com:PING"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            },
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a outage report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/entities"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a scheduled_maintenance report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/entities/1234,5678",
+        "query": "start_time=2015-03-02T14%3A22%3A51%2B10%3A30&end_time=2015-03-03T02%3A22%3A51%2B10%3A30"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a unscheduled_maintenance report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a unscheduled_maintenance report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/entities"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a downtime report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/checks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "downtime_reports": [
@@ -1675,137 +1815,30 @@
       }
     },
     {
-      "description": "a POST request with one medium",
-      "provider_state": "a contact with id 'abc' exists",
-      "request": {
-        "method": "post",
-        "path": "/contacts/abc/media",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "media": [
-            {
-              "type": "sms",
-              "address": "0123456789",
-              "interval": 300,
-              "rollup_threshold": 5
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "abc_sms"
-        ]
-      }
-    },
-    {
-      "description": "a POST request with two media",
-      "provider_state": "a contact with id 'abc' exists",
-      "request": {
-        "method": "post",
-        "path": "/contacts/abc/media",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "media": [
-            {
-              "type": "sms",
-              "address": "0123456789",
-              "interval": 300,
-              "rollup_threshold": 5
-            },
-            {
-              "type": "email",
-              "address": "ablated@example.org",
-              "interval": 180,
-              "rollup_threshold": 3
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "abc_sms",
-          "abc_email"
-        ]
-      }
-    },
-    {
-      "description": "a POST request with one medium",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "post",
-        "path": "/contacts/abc/media",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "media": [
-            {
-              "type": "sms",
-              "address": "0123456789",
-              "interval": 300,
-              "rollup_threshold": 5
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 422,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "Contact id: 'abc' could not be loaded"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for all media",
-      "provider_state": "a contact with id 'abc' has email and sms media",
+      "description": "a time limited GET request for a outage report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
       "request": {
         "method": "get",
-        "path": "/media"
+        "path": "/outage_report/entities/1234",
+        "query": "start_time=2015-03-02T14%3A22%3A51%2B10%3A30&end_time=2015-03-03T02%3A22%3A51%2B10%3A30"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
-          "media": [
+          "outage_reports": [
             {
-              "type": "email",
-              "address": "ablated@example.org",
-              "interval": 180,
-              "rollup_threshold": 3,
+              "outages": [
+
+              ],
               "links": {
-                "contacts": [
-                  "abc"
-                ]
-              }
-            },
-            {
-              "type": "sms",
-              "address": "0123456789",
-              "interval": 300,
-              "rollup_threshold": 5,
-              "links": {
-                "contacts": [
-                  "abc"
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
                 ]
               }
             }
@@ -1814,399 +1847,361 @@
       }
     },
     {
-      "description": "a GET request for sms media",
-      "provider_state": "a contact with id 'abc' has email and sms media",
+      "description": "a GET request for a status report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
       "request": {
         "method": "get",
-        "path": "/media/abc_sms"
+        "path": "/status_report/entities"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
-          "media": [
+          "status_reports": [
             {
-              "type": "sms",
-              "address": "0123456789",
-              "interval": 300,
-              "rollup_threshold": 5,
-              "links": {
-                "contacts": [
-                  "abc"
-                ]
-              }
             }
           ]
         }
       }
     },
     {
-      "description": "a GET request for email and sms media",
-      "provider_state": "a contact with id 'abc' has email and sms media",
+      "description": "a GET request for a status report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
       "request": {
         "method": "get",
-        "path": "/media/abc_email,abc_sms"
+        "path": "/status_report/entities/1234,5678"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
-          "media": [
+          "status_reports": [
             {
-              "type": "email",
-              "address": "ablated@example.org",
-              "interval": 180,
-              "rollup_threshold": 3,
-              "links": {
-                "contacts": [
-                  "abc"
-                ]
-              }
             },
             {
-              "type": "sms",
-              "address": "0123456789",
-              "interval": 300,
-              "rollup_threshold": 5,
-              "links": {
-                "contacts": [
-                  "abc"
-                ]
-              }
             }
           ]
         }
       }
     },
     {
-      "description": "a GET request for sms media",
-      "provider_state": "no contact exists",
+      "description": "a time limited GET request for a outage report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
       "request": {
         "method": "get",
-        "path": "/media/abc_sms"
+        "path": "/outage_report/checks",
+        "query": "start_time=2015-03-02T14%3A22%3A51%2B10%3A30&end_time=2015-03-03T02%3A22%3A51%2B10%3A30"
       },
       "response": {
-        "status": 404,
+        "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
-          "errors": [
-            "could not find contact 'abc'"
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
           ]
         }
       }
     },
     {
-      "description": "a PATCH request for email media",
-      "provider_state": "a contact with id 'abc' has email and sms media",
+      "description": "a time limited GET request for a scheduled_maintenance report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
       "request": {
-        "method": "patch",
-        "path": "/media/abc_email",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/media/0/interval",
-            "value": 50
-          },
-          {
-            "op": "replace",
-            "path": "/media/0/rollup_threshold",
-            "value": 3
-          }
-        ]
+        "method": "get",
+        "path": "/scheduled_maintenance_report/entities/1234",
+        "query": "start_time=2015-03-02T14%3A22%3A51%2B10%3A30&end_time=2015-03-03T02%3A22%3A51%2B10%3A30"
       },
       "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for email and sms media",
-      "provider_state": "a contact with id 'abc' has email and sms media",
-      "request": {
-        "method": "patch",
-        "path": "/media/abc_email,abc_sms",
+        "status": 200,
         "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/media/0/interval",
-            "value": 50
-          },
-          {
-            "op": "replace",
-            "path": "/media/0/rollup_threshold",
-            "value": 3
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for email media",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "patch",
-        "path": "/media/abc_email",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/media/0/interval",
-            "value": 50
-          }
-        ]
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
-          "errors": [
-            "could not find contact 'abc'"
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
           ]
         }
       }
     },
     {
-      "description": "a DELETE request for one medium",
-      "provider_state": "a contact with id 'abc' has email and sms media",
-      "request": {
-        "method": "delete",
-        "path": "/media/abc_email",
-        "body": null
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for two media",
-      "provider_state": "a contact with id 'abc' has email and sms media",
-      "request": {
-        "method": "delete",
-        "path": "/media/abc_email,abc_sms",
-        "body": null
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for one medium",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "delete",
-        "path": "/media/abc_email",
-        "body": null
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contact 'abc'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one notification rule",
-      "provider_state": "a contact with id 'abc' exists",
+      "description": "a POST request with one test notification",
+      "provider_state": "no entity exists",
       "request": {
         "method": "post",
-        "path": "/contacts/abc/notification_rules",
+        "path": "/test_notifications/entities/1234",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "notification_rules": [
+          "test_notifications": [
             {
-              "entity_tags": [
-                "database",
-                "physical"
-              ],
-              "entities": [
-                "foo-app-01.example.com"
-              ],
-              "time_restrictions": null,
-              "warning_media": [
-                "email"
-              ],
-              "critical_media": [
-                "sms",
-                "email"
-              ],
-              "warning_blackhole": false,
-              "critical_blackhole": false
+              "summary": "testing"
             }
           ]
         }
       },
       "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          {
-            "json_class": "Pact::Term",
-            "data": {
-              "generate": "05983623-fcef-42da-af44-ed6990b500fa",
-              "matcher": {"json_class":"Regexp","o":0,"s":"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"}
-            }
-          }
-        ]
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity '1234'"
+          ]
+        }
       }
     },
     {
-      "description": "a POST request with two notification rules",
-      "provider_state": "a contact with id 'abc' exists",
+      "description": "a POST request with one test notification",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
       "request": {
         "method": "post",
-        "path": "/contacts/abc/notification_rules",
+        "path": "/test_notifications/entities/1234,5678",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "notification_rules": [
+          "test_notifications": [
             {
-              "entity_tags": [
-                "database",
-                "physical"
-              ],
-              "entities": [
-                "foo-app-01.example.com"
-              ],
-              "time_restrictions": null,
-              "warning_media": [
-                "email"
-              ],
-              "critical_media": [
-                "sms",
-                "email"
-              ],
-              "warning_blackhole": false,
-              "critical_blackhole": false
+              "summary": "testing"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one test notification",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two test notifications",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+              "summary": "testing"
             },
             {
-              "entity_tags": null,
-              "entities": [
-                "foo-app-02.example.com"
-              ],
-              "time_restrictions": null,
-              "warning_media": [
-                "email"
-              ],
-              "critical_media": [
-                "sms",
-                "email"
-              ],
-              "warning_blackhole": true,
-              "critical_blackhole": false
+              "summary": "more tests"
             }
           ]
         }
       },
       "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          {
-            "json_class": "Pact::Term",
-            "data": {
-              "generate": "05983623-fcef-42da-af44-ed6990b500fa",
-              "matcher": {"json_class":"Regexp","o":0,"s":"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"}
-            }
-          },
-          {
-            "json_class": "Pact::Term",
-            "data": {
-              "generate": "20f182fc-6e32-4794-9007-97366d162c51",
-              "matcher": {"json_class":"Regexp","o":0,"s":"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"}
-            }
-          }
-        ]
+        "status": 204,
+        "body": ""
       }
     },
     {
-      "description": "a POST request with one notification rule",
-      "provider_state": "no contact exists",
+      "description": "a POST request with two test notifications",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
       "request": {
         "method": "post",
-        "path": "/contacts/abc/notification_rules",
+        "path": "/test_notifications/entities/1234,5678",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "notification_rules": [
+          "test_notifications": [
             {
-              "entity_tags": [
-                "database",
-                "physical"
-              ],
-              "entities": [
-                "foo-app-01.example.com"
-              ],
-              "time_restrictions": null,
-              "warning_media": [
-                "email"
-              ],
-              "critical_media": [
-                "sms",
-                "email"
-              ],
-              "warning_blackhole": false,
-              "critical_blackhole": false
+              "summary": "testing"
+            },
+            {
+              "summary": "more tests"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one test notification",
+      "provider_state": "no check exists",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+              "summary": "testing"
             }
           ]
         }
       },
       "response": {
         "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
         "body": {
           "errors": [
-            "could not find contact 'abc'"
+            "could not find entity 'www.example.com'"
           ]
         }
       }
     },
     {
-      "description": "a GET request for all notification rules",
+      "description": "a POST request with one test notification",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/checks/www.example.com:SSH,www2.example.com:PING",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+              "summary": "testing"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one test notification",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+              "summary": "testing"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two test notifications",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+              "summary": "testing"
+            },
+            {
+              "summary": "more tests"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two test notifications",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/checks/www.example.com:SSH,www2.example.com:PING",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+              "summary": "testing"
+            },
+            {
+              "summary": "more tests"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a GET request for a single notification rule",
       "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
       "request": {
         "method": "get",
-        "path": "/notification_rules"
+        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "notification_rules": [
@@ -2242,16 +2237,16 @@
       }
     },
     {
-      "description": "a GET request for a single notification rule",
+      "description": "a GET request for all notification rules",
       "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
       "request": {
         "method": "get",
-        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa"
+        "path": "/notification_rules"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "notification_rules": [
@@ -2296,7 +2291,7 @@
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "notification_rules": [
@@ -2368,7 +2363,7 @@
       "response": {
         "status": 404,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "errors": [
@@ -2378,25 +2373,169 @@
       }
     },
     {
-      "description": "a PATCH request to change properties for a single notification rule",
-      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
+      "description": "a POST request with two notification rules",
+      "provider_state": "a contact with id 'abc' exists",
       "request": {
-        "method": "patch",
-        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa",
+        "method": "post",
+        "path": "/contacts/abc/notification_rules",
         "headers": {
-          "Content-Type": "application/json-patch+json"
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "notification_rules": [
+            {
+              "entity_tags": [
+                "database",
+                "physical"
+              ],
+              "entities": [
+                "foo-app-01.example.com"
+              ],
+              "time_restrictions": null,
+              "warning_media": [
+                "email"
+              ],
+              "critical_media": [
+                "sms",
+                "email"
+              ],
+              "warning_blackhole": false,
+              "critical_blackhole": false
+            },
+            {
+              "entity_tags": null,
+              "entities": [
+                "foo-app-02.example.com"
+              ],
+              "time_restrictions": null,
+              "warning_media": [
+                "email"
+              ],
+              "critical_media": [
+                "sms",
+                "email"
+              ],
+              "warning_blackhole": true,
+              "critical_blackhole": false
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": [
           {
-            "op": "replace",
-            "path": "/notification_rules/0/warning_blackhole",
-            "value": false
+            "json_class": "Pact::Term",
+            "data": {
+              "generate": "05983623-fcef-42da-af44-ed6990b500fa",
+              "matcher": {"json_class":"Regexp","o":0,"s":"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"}
+            }
+          },
+          {
+            "json_class": "Pact::Term",
+            "data": {
+              "generate": "20f182fc-6e32-4794-9007-97366d162c51",
+              "matcher": {"json_class":"Regexp","o":0,"s":"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"}
+            }
           }
         ]
+      }
+    },
+    {
+      "description": "a POST request with one notification rule",
+      "provider_state": "a contact with id 'abc' exists",
+      "request": {
+        "method": "post",
+        "path": "/contacts/abc/notification_rules",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "notification_rules": [
+            {
+              "entity_tags": [
+                "database",
+                "physical"
+              ],
+              "entities": [
+                "foo-app-01.example.com"
+              ],
+              "time_restrictions": null,
+              "warning_media": [
+                "email"
+              ],
+              "critical_media": [
+                "sms",
+                "email"
+              ],
+              "warning_blackhole": false,
+              "critical_blackhole": false
+            }
+          ]
+        }
       },
       "response": {
-        "status": 204,
-        "body": ""
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": [
+          {
+            "json_class": "Pact::Term",
+            "data": {
+              "generate": "05983623-fcef-42da-af44-ed6990b500fa",
+              "matcher": {"json_class":"Regexp","o":0,"s":"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "description": "a POST request with one notification rule",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "post",
+        "path": "/contacts/abc/notification_rules",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "notification_rules": [
+            {
+              "entity_tags": [
+                "database",
+                "physical"
+              ],
+              "entities": [
+                "foo-app-01.example.com"
+              ],
+              "time_restrictions": null,
+              "warning_media": [
+                "email"
+              ],
+              "critical_media": [
+                "sms",
+                "email"
+              ],
+              "warning_blackhole": false,
+              "critical_blackhole": false
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contact 'abc'"
+          ]
+        }
       }
     },
     {
@@ -2423,6 +2562,28 @@
     },
     {
       "description": "a PATCH request to change properties for a single notification rule",
+      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
+      "request": {
+        "method": "patch",
+        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/notification_rules/0/warning_blackhole",
+            "value": false
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request to change properties for a single notification rule",
       "provider_state": "no notification rule exists",
       "request": {
         "method": "patch",
@@ -2441,7 +2602,7 @@
       "response": {
         "status": 404,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "errors": [
@@ -2451,11 +2612,11 @@
       }
     },
     {
-      "description": "a DELETE request for a single notification rule",
-      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
+      "description": "a DELETE request for two notification rules",
+      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' and notification rule '20f182fc-6e32-4794-9007-97366d162c51' exists",
       "request": {
         "method": "delete",
-        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa",
+        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa,20f182fc-6e32-4794-9007-97366d162c51",
         "body": null
       },
       "response": {
@@ -2464,11 +2625,11 @@
       }
     },
     {
-      "description": "a DELETE request for two notification rules",
-      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' and notification rule '20f182fc-6e32-4794-9007-97366d162c51' exists",
+      "description": "a DELETE request for a single notification rule",
+      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
       "request": {
         "method": "delete",
-        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa,20f182fc-6e32-4794-9007-97366d162c51",
+        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa",
         "body": null
       },
       "response": {
@@ -2487,7 +2648,7 @@
       "response": {
         "status": 404,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "errors": [
@@ -2497,18 +2658,90 @@
       }
     },
     {
-      "description": "a POST request with one test notification",
+      "description": "a PATCH request for an unscheduled maintenance period",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "patch",
+        "path": "/unscheduled_maintenances/entities/1234,5678",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/unscheduled_maintenances/0/end_time",
+            "value": "2015-03-02T14:22:52+10:30"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for an unscheduled maintenance period",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "patch",
+        "path": "/unscheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/unscheduled_maintenances/0/end_time",
+            "value": "2015-03-02T14:22:52+10:30"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for an unscheduled maintenance period",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "patch",
+        "path": "/unscheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/unscheduled_maintenances/0/end_time",
+            "value": "2015-03-02T14:22:52+10:30"
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity '1234'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a POST request with one scheduled maintenance period",
       "provider_state": "no entity exists",
       "request": {
         "method": "post",
-        "path": "/test_notifications/entities/1234",
+        "path": "/scheduled_maintenances/entities/1234",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "test_notifications": [
+          "scheduled_maintenances": [
             {
-              "summary": "testing"
+              "start_time": "2015-03-02T14:22:52+10:30",
+              "duration": 3600,
+              "summary": "working"
             }
           ]
         }
@@ -2523,39 +2756,20 @@
       }
     },
     {
-      "description": "a POST request with one test notification",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "post",
-        "path": "/test_notifications/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "test_notifications": [
-            {
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one test notification",
+      "description": "a POST request with one scheduled maintenance period",
       "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
       "request": {
         "method": "post",
-        "path": "/test_notifications/entities/1234,5678",
+        "path": "/scheduled_maintenances/entities/1234,5678",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "test_notifications": [
+          "scheduled_maintenances": [
             {
-              "summary": "testing"
+              "start_time": "2015-03-02T14:22:52+10:30",
+              "duration": 3600,
+              "summary": "working"
             }
           ]
         }
@@ -2566,21 +2780,20 @@
       }
     },
     {
-      "description": "a POST request with two test notifications",
+      "description": "a POST request with one scheduled maintenance period",
       "provider_state": "an entity 'www.example.com' with id '1234' exists",
       "request": {
         "method": "post",
-        "path": "/test_notifications/entities/1234",
+        "path": "/scheduled_maintenances/entities/1234",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "test_notifications": [
+          "scheduled_maintenances": [
             {
-              "summary": "testing"
-            },
-            {
-              "summary": "more tests"
+              "start_time": "2015-03-02T14:22:52+10:30",
+              "duration": 3600,
+              "summary": "working"
             }
           ]
         }
@@ -2591,21 +2804,54 @@
       }
     },
     {
-      "description": "a POST request with two test notifications",
+      "description": "a POST request with two scheduled maintenance periods",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "post",
+        "path": "/scheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "scheduled_maintenances": [
+            {
+              "start_time": "2015-03-02T14:22:52+10:30",
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "start_time": "2015-03-02T16:22:52+10:30",
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two scheduled maintenance periods",
       "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
       "request": {
         "method": "post",
-        "path": "/test_notifications/entities/1234,5678",
+        "path": "/scheduled_maintenances/entities/1234,5678",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "test_notifications": [
+          "scheduled_maintenances": [
             {
-              "summary": "testing"
+              "start_time": "2015-03-02T14:22:52+10:30",
+              "duration": 3600,
+              "summary": "working"
             },
             {
-              "summary": "more tests"
+              "start_time": "2015-03-02T16:22:52+10:30",
+              "duration": 3600,
+              "summary": "more work"
             }
           ]
         }
@@ -2616,18 +2862,260 @@
       }
     },
     {
-      "description": "a POST request with one test notification",
+      "description": "a POST request with one unscheduled maintenance period",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity '1234'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a POST request with one unscheduled maintenance period",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/entities/1234,5678",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one unscheduled maintenance period",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two unscheduled maintenance periods",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two unscheduled maintenance periods",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/entities/1234,5678",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for a scheduled maintenance period",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "delete",
+        "path": "/scheduled_maintenances/entities/1234,5678",
+        "query": "start_time=2015-03-02T14%3A22%3A52%2B10%3A30"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for a scheduled maintenance period",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "delete",
+        "path": "/scheduled_maintenances/entities/1234",
+        "query": "start_time=2015-03-02T14%3A22%3A52%2B10%3A30"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for a scheduled maintenance period",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "delete",
+        "path": "/scheduled_maintenances/entities/1234",
+        "query": "start_time=2015-03-02T14%3A22%3A52%2B10%3A30"
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity '1234'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a PATCH request for an unscheduled maintenance period",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "patch",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/unscheduled_maintenances/0/end_time",
+            "value": "2015-03-02T14:22:52+10:30"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for an unscheduled maintenance period",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "patch",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/unscheduled_maintenances/0/end_time",
+            "value": "2015-03-02T14:22:52+10:30"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for an unscheduled maintenance period",
+      "provider_state": "no check exists",
+      "request": {
+        "method": "patch",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/unscheduled_maintenances/0/end_time",
+            "value": "2015-03-02T14:22:52+10:30"
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity 'www.example.com'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a POST request with one scheduled maintenance period",
       "provider_state": "no check exists",
       "request": {
         "method": "post",
-        "path": "/test_notifications/checks/www.example.com:SSH",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "test_notifications": [
+          "scheduled_maintenances": [
             {
-              "summary": "testing"
+              "start_time": "2015-03-02T14:22:52+10:30",
+              "duration": 3600,
+              "summary": "working"
             }
           ]
         }
@@ -2642,40 +3130,20 @@
       }
     },
     {
-      "description": "a POST request with one test notification",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "post",
-        "path": "/test_notifications/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "test_notifications": [
-            {
-              "summary": "testing"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one test notification",
+      "description": "a POST request with one scheduled maintenance period",
       "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
       "request": {
         "method": "post",
-        "path": "/test_notifications/checks/www.example.com:SSH,www2.example.com:PING",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "test_notifications": [
+          "scheduled_maintenances": [
             {
-              "summary": "testing"
+              "start_time": "2015-03-02T14:22:52+10:30",
+              "duration": 3600,
+              "summary": "working"
             }
           ]
         }
@@ -2686,21 +3154,20 @@
       }
     },
     {
-      "description": "a POST request with two test notifications",
+      "description": "a POST request with one scheduled maintenance period",
       "provider_state": "a check 'www.example.com:SSH' exists",
       "request": {
         "method": "post",
-        "path": "/test_notifications/checks/www.example.com:SSH",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "test_notifications": [
+          "scheduled_maintenances": [
             {
-              "summary": "testing"
-            },
-            {
-              "summary": "more tests"
+              "start_time": "2015-03-02T14:22:52+10:30",
+              "duration": 3600,
+              "summary": "working"
             }
           ]
         }
@@ -2711,21 +3178,54 @@
       }
     },
     {
-      "description": "a POST request with two test notifications",
+      "description": "a POST request with two scheduled maintenance periods",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "post",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "scheduled_maintenances": [
+            {
+              "start_time": "2015-03-02T14:22:52+10:30",
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "start_time": "2015-03-02T16:22:52+10:30",
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two scheduled maintenance periods",
       "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
       "request": {
         "method": "post",
-        "path": "/test_notifications/checks/www.example.com:SSH,www2.example.com:PING",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "test_notifications": [
+          "scheduled_maintenances": [
             {
-              "summary": "testing"
+              "start_time": "2015-03-02T14:22:52+10:30",
+              "duration": 3600,
+              "summary": "working"
             },
             {
-              "summary": "more tests"
+              "start_time": "2015-03-02T16:22:52+10:30",
+              "duration": 3600,
+              "summary": "more work"
             }
           ]
         }
@@ -2736,13 +3236,942 @@
       }
     },
     {
-      "description": "a POST request with one contact",
+      "description": "a POST request with one unscheduled maintenance period",
+      "provider_state": "no check exists",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity 'www.example.com'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a POST request with one unscheduled maintenance period",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one unscheduled maintenance period",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two unscheduled maintenance periods",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two unscheduled maintenance periods",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for a scheduled maintenance period",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "delete",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
+        "query": "start_time=2015-03-02T14%3A22%3A53%2B10%3A30"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for a scheduled maintenance period",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "delete",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
+        "query": "start_time=2015-03-02T14%3A22%3A53%2B10%3A30"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for a scheduled maintenance period",
+      "provider_state": "no check exists",
+      "request": {
+        "method": "delete",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
+        "query": "start_time=2015-03-02T14%3A22%3A53%2B10%3A30"
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity 'www.example.com'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for sms media",
+      "provider_state": "a contact with id 'abc' has email and sms media",
+      "request": {
+        "method": "get",
+        "path": "/media/abc_sms"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "media": [
+            {
+              "type": "sms",
+              "address": "0123456789",
+              "interval": 300,
+              "rollup_threshold": 5,
+              "links": {
+                "contacts": [
+                  "abc"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all media",
+      "provider_state": "a contact with id 'abc' has email and sms media",
+      "request": {
+        "method": "get",
+        "path": "/media"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "media": [
+            {
+              "type": "email",
+              "address": "ablated@example.org",
+              "interval": 180,
+              "rollup_threshold": 3,
+              "links": {
+                "contacts": [
+                  "abc"
+                ]
+              }
+            },
+            {
+              "type": "sms",
+              "address": "0123456789",
+              "interval": 300,
+              "rollup_threshold": 5,
+              "links": {
+                "contacts": [
+                  "abc"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for email and sms media",
+      "provider_state": "a contact with id 'abc' has email and sms media",
+      "request": {
+        "method": "get",
+        "path": "/media/abc_email,abc_sms"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "media": [
+            {
+              "type": "email",
+              "address": "ablated@example.org",
+              "interval": 180,
+              "rollup_threshold": 3,
+              "links": {
+                "contacts": [
+                  "abc"
+                ]
+              }
+            },
+            {
+              "type": "sms",
+              "address": "0123456789",
+              "interval": 300,
+              "rollup_threshold": 5,
+              "links": {
+                "contacts": [
+                  "abc"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for sms media",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "get",
+        "path": "/media/abc_sms"
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contact 'abc'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a POST request with two media",
+      "provider_state": "a contact with id 'abc' exists",
+      "request": {
+        "method": "post",
+        "path": "/contacts/abc/media",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "media": [
+            {
+              "type": "sms",
+              "address": "0123456789",
+              "interval": 300,
+              "rollup_threshold": 5
+            },
+            {
+              "type": "email",
+              "address": "ablated@example.org",
+              "interval": 180,
+              "rollup_threshold": 3
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": [
+          "abc_sms",
+          "abc_email"
+        ]
+      }
+    },
+    {
+      "description": "a POST request with one medium",
+      "provider_state": "a contact with id 'abc' exists",
+      "request": {
+        "method": "post",
+        "path": "/contacts/abc/media",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "media": [
+            {
+              "type": "sms",
+              "address": "0123456789",
+              "interval": 300,
+              "rollup_threshold": 5
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": [
+          "abc_sms"
+        ]
+      }
+    },
+    {
+      "description": "a POST request with one medium",
       "provider_state": "no contact exists",
       "request": {
         "method": "post",
-        "path": "/contacts",
+        "path": "/contacts/abc/media",
         "headers": {
           "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "media": [
+            {
+              "type": "sms",
+              "address": "0123456789",
+              "interval": 300,
+              "rollup_threshold": 5
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 422,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "errors": [
+            "Contact id: 'abc' could not be loaded"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a PATCH request for email and sms media",
+      "provider_state": "a contact with id 'abc' has email and sms media",
+      "request": {
+        "method": "patch",
+        "path": "/media/abc_email,abc_sms",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/media/0/interval",
+            "value": 50
+          },
+          {
+            "op": "replace",
+            "path": "/media/0/rollup_threshold",
+            "value": 3
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for email media",
+      "provider_state": "a contact with id 'abc' has email and sms media",
+      "request": {
+        "method": "patch",
+        "path": "/media/abc_email",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/media/0/interval",
+            "value": 50
+          },
+          {
+            "op": "replace",
+            "path": "/media/0/rollup_threshold",
+            "value": 3
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for email media",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "patch",
+        "path": "/media/abc_email",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/media/0/interval",
+            "value": 50
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contact 'abc'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a DELETE request for two media",
+      "provider_state": "a contact with id 'abc' has email and sms media",
+      "request": {
+        "method": "delete",
+        "path": "/media/abc_email,abc_sms",
+        "body": null
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for one medium",
+      "provider_state": "a contact with id 'abc' has email and sms media",
+      "request": {
+        "method": "delete",
+        "path": "/media/abc_email",
+        "body": null
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for one medium",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "delete",
+        "path": "/media/abc_email",
+        "body": null
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contact 'abc'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all entities",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "get",
+        "path": "/entities"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "entities": [
+            {
+              "name": "www.example.com",
+              "id": "1234"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all entities",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "get",
+        "path": "/entities"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "entities": [
+
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a single entity",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "get",
+        "path": "/entities/1234"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "entities": [
+            {
+              "name": "www.example.com",
+              "id": "1234"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a single entity",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "get",
+        "path": "/entities/1234"
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "errors": [
+            "could not find entities: '1234'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a POST request with one entity",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "post",
+        "path": "/entities",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "entities": [
+            {
+              "name": "example.org",
+              "id": "57_example"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": [
+          "57_example"
+        ]
+      }
+    },
+    {
+      "description": "a POST request with two entities",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "post",
+        "path": "/entities",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "entities": [
+            {
+              "name": "example.org",
+              "id": "57_example"
+            },
+            {
+              "name": "example2.org",
+              "id": "58"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": [
+          "57_example",
+          "58"
+        ]
+      }
+    },
+    {
+      "description": "a PATCH request for a single entity",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "patch",
+        "path": "/entities/1234",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/entities/0/name",
+            "value": "example3.com"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for a single entity",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "patch",
+        "path": "/entities/1234",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/entities/0/name",
+            "value": "example3.com"
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "errors": [
+            "could not find entity '1234'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all checks",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "get",
+        "path": "/checks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "checks": [
+
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/checks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "checks": [
+            {
+              "id": "www.example.com:SSH",
+              "name": "SSH",
+              "entity_name": "www.example.com",
+              "links": {
+                "entities": [
+                  "1234"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for check 'www.example.com:SSH'",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/checks/www.example.com:SSH"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "checks": [
+            {
+              "id": "www.example.com:SSH",
+              "name": "SSH",
+              "entity_name": "www.example.com",
+              "links": {
+                "entities": [
+                  "1234"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for check 'www.example.com:SSH'",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "get",
+        "path": "/checks/www.example.com:SSH"
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "errors": [
+            "could not find entity checks: 'www.example.com:SSH'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a POST request with one check",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "post",
+        "path": "/checks",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "checks": [
+            {
+              "name": "SSH",
+              "entity_id": "1234"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": [
+          "www.example.com:SSH"
+        ]
+      }
+    },
+    {
+      "description": "a POST request with two checks",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "post",
+        "path": "/checks",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "checks": [
+            {
+              "name": "SSH",
+              "entity_id": "1234"
+            },
+            {
+              "name": "PING",
+              "entity_id": "5678"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": [
+          "www.example.com:SSH",
+          "www2.example.com:PING"
+        ]
+      }
+    },
+    {
+      "description": "a PATCH request for a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "patch",
+        "path": "/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/checks/0/enabled",
+            "value": false
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for a single check",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "patch",
+        "path": "/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/checks/0/enabled",
+            "value": false
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "errors": [
+            "could not find entity 'www.example.com'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all contacts",
+      "provider_state": "a contact with id 'abc' exists",
+      "request": {
+        "method": "get",
+        "path": "/contacts"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "contacts": [
@@ -2755,15 +4184,69 @@
             }
           ]
         }
+      }
+    },
+    {
+      "description": "a GET request for all contacts",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "get",
+        "path": "/contacts"
       },
       "response": {
-        "status": 201,
+        "status": 200,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
-        "body": [
-          "abc"
-        ]
+        "body": {
+          "contacts": [
+
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a single contact",
+      "provider_state": "a contact with id 'abc' exists",
+      "request": {
+        "method": "get",
+        "path": "/contacts/abc"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "contacts": [
+            {
+              "id": "abc",
+              "first_name": "Jim",
+              "last_name": "Smith",
+              "email": "jims@example.com",
+              "timezone": "UTC"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a single contact",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "get",
+        "path": "/contacts/abc"
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contacts 'abc'"
+          ]
+        }
       }
     },
     {
@@ -2796,11 +4279,42 @@
       "response": {
         "status": 201,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": [
           "abc",
           "def"
+        ]
+      }
+    },
+    {
+      "description": "a POST request with one contact",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "post",
+        "path": "/contacts",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "contacts": [
+            {
+              "id": "abc",
+              "first_name": "Jim",
+              "last_name": "Smith",
+              "email": "jims@example.com",
+              "timezone": "UTC"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
+        },
+        "body": [
+          "abc"
         ]
       }
     },
@@ -2828,99 +4342,11 @@
       "response": {
         "status": 409,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "errors": [
             "Contacts already exist with the following IDs: abc"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for all contacts",
-      "provider_state": "a contact with id 'abc' exists",
-      "request": {
-        "method": "get",
-        "path": "/contacts"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "contacts": [
-            {
-              "id": "abc",
-              "first_name": "Jim",
-              "last_name": "Smith",
-              "email": "jims@example.com",
-              "timezone": "UTC"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for all contacts",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "get",
-        "path": "/contacts"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "contacts": [
-
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a single contact",
-      "provider_state": "a contact with id 'abc' exists",
-      "request": {
-        "method": "get",
-        "path": "/contacts/abc"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "contacts": [
-            {
-              "id": "abc",
-              "first_name": "Jim",
-              "last_name": "Smith",
-              "email": "jims@example.com",
-              "timezone": "UTC"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a single contact",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "get",
-        "path": "/contacts/abc"
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contacts 'abc'"
           ]
         }
       }
@@ -2945,7 +4371,7 @@
       "response": {
         "status": 404,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "errors": [
@@ -2955,11 +4381,11 @@
       }
     },
     {
-      "description": "a PATCH request to change properties for a single contact",
-      "provider_state": "a contact with id 'abc' exists",
+      "description": "a PATCH request to change properties for two contacts",
+      "provider_state": "contacts with ids 'abc' and '872' exist",
       "request": {
         "method": "patch",
-        "path": "/contacts/abc",
+        "path": "/contacts/abc,872",
         "headers": {
           "Content-Type": "application/json-patch+json"
         },
@@ -2977,11 +4403,11 @@
       }
     },
     {
-      "description": "a PATCH request to change properties for two contacts",
-      "provider_state": "contacts with ids 'abc' and '872' exist",
+      "description": "a PATCH request to change properties for a single contact",
+      "provider_state": "a contact with id 'abc' exists",
       "request": {
         "method": "patch",
-        "path": "/contacts/abc,872",
+        "path": "/contacts/abc",
         "headers": {
           "Content-Type": "application/json-patch+json"
         },
@@ -3043,19 +4469,6 @@
       }
     },
     {
-      "description": "a DELETE request for a single contact",
-      "provider_state": "a contact with id 'abc' exists",
-      "request": {
-        "method": "delete",
-        "path": "/contacts/abc",
-        "body": null
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
       "description": "a DELETE request for two contacts",
       "provider_state": "contacts with ids 'abc' and '872' exist",
       "request": {
@@ -3070,6 +4483,19 @@
     },
     {
       "description": "a DELETE request for a single contact",
+      "provider_state": "a contact with id 'abc' exists",
+      "request": {
+        "method": "delete",
+        "path": "/contacts/abc",
+        "body": null
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for a single contact",
       "provider_state": "no contact exists",
       "request": {
         "method": "delete",
@@ -3079,1437 +4505,11 @@
       "response": {
         "status": 404,
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json; charset=UTF-8"
         },
         "body": {
           "errors": [
             "could not find contacts 'abc'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one check",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "post",
-        "path": "/checks",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "checks": [
-            {
-              "name": "SSH",
-              "entity_id": "1234"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "www.example.com:SSH"
-        ]
-      }
-    },
-    {
-      "description": "a POST request with two checks",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "post",
-        "path": "/checks",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "checks": [
-            {
-              "name": "SSH",
-              "entity_id": "1234"
-            },
-            {
-              "name": "PING",
-              "entity_id": "5678"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "www.example.com:SSH",
-          "www2.example.com:PING"
-        ]
-      }
-    },
-    {
-      "description": "a GET request for all checks",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "get",
-        "path": "/checks"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "checks": [
-
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/checks"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "checks": [
-            {
-              "id": "www.example.com:SSH",
-              "name": "SSH",
-              "entity_name": "www.example.com",
-              "links": {
-                "entities": [
-                  "1234"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for check 'www.example.com:SSH'",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/checks/www.example.com:SSH"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "checks": [
-            {
-              "id": "www.example.com:SSH",
-              "name": "SSH",
-              "entity_name": "www.example.com",
-              "links": {
-                "entities": [
-                  "1234"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for check 'www.example.com:SSH'",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "get",
-        "path": "/checks/www.example.com:SSH"
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find entity checks: 'www.example.com:SSH'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a PATCH request for a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "patch",
-        "path": "/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/checks/0/enabled",
-            "value": false
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for a single check",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "patch",
-        "path": "/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/checks/0/enabled",
-            "value": false
-          }
-        ]
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find entity 'www.example.com'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one entity",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "post",
-        "path": "/entities",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "entities": [
-            {
-              "name": "example.org",
-              "id": "57_example"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "57_example"
-        ]
-      }
-    },
-    {
-      "description": "a POST request with two entities",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "post",
-        "path": "/entities",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "entities": [
-            {
-              "name": "example.org",
-              "id": "57_example"
-            },
-            {
-              "name": "example2.org",
-              "id": "58"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "57_example",
-          "58"
-        ]
-      }
-    },
-    {
-      "description": "a GET request for all entities",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "get",
-        "path": "/entities"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "entities": [
-            {
-              "name": "www.example.com",
-              "id": "1234"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for all entities",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "get",
-        "path": "/entities"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "entities": [
-
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a single entity",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "get",
-        "path": "/entities/1234"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "entities": [
-            {
-              "name": "www.example.com",
-              "id": "1234"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a single entity",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "get",
-        "path": "/entities/1234"
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find entities: '1234'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a PATCH request for a single entity",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "patch",
-        "path": "/entities/1234",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/entities/0/name",
-            "value": "example3.com"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for a single entity",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "patch",
-        "path": "/entities/1234",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/entities/0/name",
-            "value": "example3.com"
-          }
-        ]
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find entity '1234'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one scheduled maintenance period",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:31+10:30",
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity '1234'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one scheduled maintenance period",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:31+10:30",
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one scheduled maintenance period",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/entities/1234,5678",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:31+10:30",
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two scheduled maintenance periods",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:31+10:30",
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "start_time": "2014-12-02T12:31:31+10:30",
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two scheduled maintenance periods",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/entities/1234,5678",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:31+10:30",
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "start_time": "2014-12-02T12:31:31+10:30",
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one unscheduled maintenance period",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity '1234'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one unscheduled maintenance period",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one unscheduled maintenance period",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/entities/1234,5678",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two unscheduled maintenance periods",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two unscheduled maintenance periods",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/entities/1234,5678",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for an unscheduled maintenance period",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "patch",
-        "path": "/unscheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/unscheduled_maintenances/0/end_time",
-            "value": "2014-12-02T10:31:31+10:30"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for an unscheduled maintenance period",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "patch",
-        "path": "/unscheduled_maintenances/entities/1234,5678",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/unscheduled_maintenances/0/end_time",
-            "value": "2014-12-02T10:31:31+10:30"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for an unscheduled maintenance period",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "patch",
-        "path": "/unscheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/unscheduled_maintenances/0/end_time",
-            "value": "2014-12-02T10:31:32+10:30"
-          }
-        ]
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity '1234'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a DELETE request for a scheduled maintenance period",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "delete",
-        "path": "/scheduled_maintenances/entities/1234",
-        "query": "start_time=2014-12-02T10%3A31%3A32%2B10%3A30"
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for a scheduled maintenance period",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "delete",
-        "path": "/scheduled_maintenances/entities/1234,5678",
-        "query": "start_time=2014-12-02T10%3A31%3A32%2B10%3A30"
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for a scheduled maintenance period",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "delete",
-        "path": "/scheduled_maintenances/entities/1234",
-        "query": "start_time=2014-12-02T10%3A31%3A32%2B10%3A30"
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity '1234'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one scheduled maintenance period",
-      "provider_state": "no check exists",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:32+10:30",
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity 'www.example.com'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one scheduled maintenance period",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:32+10:30",
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one scheduled maintenance period",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:32+10:30",
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two scheduled maintenance periods",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:32+10:30",
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "start_time": "2014-12-02T12:31:32+10:30",
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two scheduled maintenance periods",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:32+10:30",
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "start_time": "2014-12-02T12:31:32+10:30",
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one unscheduled maintenance period",
-      "provider_state": "no check exists",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity 'www.example.com'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one unscheduled maintenance period",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one unscheduled maintenance period",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two unscheduled maintenance periods",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two unscheduled maintenance periods",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for an unscheduled maintenance period",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "patch",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/unscheduled_maintenances/0/end_time",
-            "value": "2014-12-02T10:31:32+10:30"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for an unscheduled maintenance period",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "patch",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/unscheduled_maintenances/0/end_time",
-            "value": "2014-12-02T10:31:32+10:30"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for an unscheduled maintenance period",
-      "provider_state": "no check exists",
-      "request": {
-        "method": "patch",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/unscheduled_maintenances/0/end_time",
-            "value": "2014-12-02T10:31:32+10:30"
-          }
-        ]
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity 'www.example.com'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a DELETE request for a scheduled maintenance period",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "delete",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
-        "query": "start_time=2014-12-02T10%3A31%3A32%2B10%3A30"
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for a scheduled maintenance period",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "delete",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
-        "query": "start_time=2014-12-02T10%3A31%3A32%2B10%3A30"
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for a scheduled maintenance period",
-      "provider_state": "no check exists",
-      "request": {
-        "method": "delete",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
-        "query": "start_time=2014-12-02T10%3A31%3A32%2B10%3A30"
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity 'www.example.com'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one set of pagerduty credentials",
-      "provider_state": "a contact with id 'abc' exists",
-      "request": {
-        "method": "post",
-        "path": "/contacts/abc/pagerduty_credentials",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "pagerduty_credentials": [
-            {
-              "service_key": "abc",
-              "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "abc"
-        ]
-      }
-    },
-    {
-      "description": "a POST request with one set of pagerduty credentials",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "post",
-        "path": "/contacts/abc/pagerduty_credentials",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "pagerduty_credentials": [
-            {
-              "service_key": "abc",
-              "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 422,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "Contact id: 'abc' could not be loaded"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for all pagerduty credentials",
-      "provider_state": "a contact with id 'abc' has pagerduty credentials",
-      "request": {
-        "method": "get",
-        "path": "/pagerduty_credentials"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "pagerduty_credentials": [
-            {
-              "service_key": "abc",
-              "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for one set of pagerduty credentials",
-      "provider_state": "a contact with id 'abc' has pagerduty credentials",
-      "request": {
-        "method": "get",
-        "path": "/pagerduty_credentials/abc"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "pagerduty_credentials": [
-            {
-              "service_key": "abc",
-              "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for two sets of pagerduty credentials",
-      "provider_state": "contacts with ids 'abc' and '872' have pagerduty credentials",
-      "request": {
-        "method": "get",
-        "path": "/pagerduty_credentials/abc,872"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "pagerduty_credentials": [
-            {
-              "service_key": "abc",
-              "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
-            },
-            {
-              "service_key": "mno",
-              "subdomain": "pqr",
-              "username": "stu",
-              "password": "vwx"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for one set of pagerduty credentials",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "get",
-        "path": "/pagerduty_credentials/abc"
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contact 'abc'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a PATCH request for pagerduty credentials",
-      "provider_state": "a contact with id 'abc' has pagerduty credentials",
-      "request": {
-        "method": "patch",
-        "path": "/pagerduty_credentials/abc",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/pagerduty_credentials/0/password",
-            "value": "pswrd"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for pagerduty credentials",
-      "provider_state": "contacts with ids 'abc' and '872' have pagerduty credentials",
-      "request": {
-        "method": "patch",
-        "path": "/pagerduty_credentials/abc,872",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/pagerduty_credentials/0/password",
-            "value": "pswrd"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for pagerduty credentials",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "patch",
-        "path": "/pagerduty_credentials/abc",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/pagerduty_credentials/0/password",
-            "value": "pswrd"
-          }
-        ]
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contact 'abc'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a DELETE request for one set of pagerduty credentials",
-      "provider_state": "a contact with id 'abc' has pagerduty credentials",
-      "request": {
-        "method": "delete",
-        "path": "/pagerduty_credentials/abc",
-        "body": null
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for two sets of pagerduty credentials",
-      "provider_state": "contacts with ids 'abc' and '872' have pagerduty credentials",
-      "request": {
-        "method": "delete",
-        "path": "/pagerduty_credentials/abc,872",
-        "body": null
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for one set of pagerduty credentials",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "delete",
-        "path": "/pagerduty_credentials/abc",
-        "body": null
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contact 'abc'"
           ]
         }
       }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+Encoding.default_internal = 'UTF-8'
+
 if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start do
@@ -7,8 +9,6 @@ if ENV['COVERAGE']
     SimpleCov.result.format!
   end
 end
-
-$testing = true
 
 FLAPJACK_ENV    = ENV["FLAPJACK_ENV"] || 'test'
 FLAPJACK_ROOT   = File.join(File.dirname(__FILE__), '..')

--- a/spec/support/jsonapi_helper.rb
+++ b/spec/support/jsonapi_helper.rb
@@ -52,7 +52,8 @@ module JsonapiHelper
         expect(last_response.headers['Access-Control-Allow-Origin']).to eq("*")
         unless last_response.status == 204
           expect(Flapjack.load_json(last_response.body)).to be_a(Enumerable)
-          expect(last_response.headers['Content-Type']).to eq(Flapjack::Gateways::JSONAPI::JSONAPI_MEDIA_TYPE)
+          ct = "#{Flapjack::Gateways::JSONAPI::JSONAPI_MEDIA_TYPE}; charset=UTF-8"
+          expect(last_response.headers['Content-Type']).to eq(ct)
         end
       end
     end


### PR DESCRIPTION
If people have configured external templates for the gateways, the encoding is assumed to match whatever Flapjack's configured for (UTF-8 unless it was called with `--no-force-utf8`, value from `ENV[LANG]` otherwise). We enforce UTF-8 for the files we ship with the gem.

Also sets the configured encoding on web pages and JSONAPI responses, and tries to do some sanity checking for common offenders in received data.

This is probably an improvement but likely not a 100% solution for the problem.

See #801 and #802.