### PR TITLE
Add 'host' config option for pikelets

### DIFF
--- a/etc/flapjack_config.toml.example
+++ b/etc/flapjack_config.toml.example
@@ -166,6 +166,7 @@ daemonize = true
   # Browsable web interface
   [gateways.web]
     enabled = true
+    #bind_address = "127.0.0.1"
     port = 3080
     timeout = 300
     # Seconds between auto_refresh of entities/checks pages.  Set to 0 to disable
@@ -181,6 +182,7 @@ daemonize = true
   # HTTP API server
   [gateways.jsonapi]
     enabled = true
+    #bind_address = "127.0.0.1"
     port = 3081
     timeout = 300
     access_log = "/var/log/flapjack/jsonapi_access.log"

--- a/lib/flapjack/pikelet.rb
+++ b/lib/flapjack/pikelet.rb
@@ -163,18 +163,18 @@ module Flapjack
         @pikelet_class.instance_variable_set('@config', @config)
 
         if @config
-          host = @config['host']
+          bind_address = @config['bind_address']
           port = @config['port']
           port = port.nil? ? nil : port.to_i
           timeout = @config['timeout']
           timeout = timeout.nil? ? 300 : timeout.to_i
         end
-        host = '127.0.0.1' if (host.nil?)
+        bind_address = '127.0.0.1' if (bind_address.nil?)
         port = 3001 if (port.nil? || port <= 0 || port > 65535)
 
         super do
           @pikelet_class.start if @pikelet_class.respond_to?(:start)
-          @server = ::WEBrick::HTTPServer.new(:Port => port, :BindAddress => host,
+          @server = ::WEBrick::HTTPServer.new(:Port => port, :BindAddress => bind_address,
             :AccessLog => [], :Logger => WEBrick::Log::new("/dev/null", 7))
           @server.mount "/", Rack::Handler::WEBrick, @pikelet_class
           yield @server if block_given?

--- a/lib/flapjack/pikelet.rb
+++ b/lib/flapjack/pikelet.rb
@@ -163,16 +163,18 @@ module Flapjack
         @pikelet_class.instance_variable_set('@config', @config)
 
         if @config
+          host = @config['host']
           port = @config['port']
           port = port.nil? ? nil : port.to_i
           timeout = @config['timeout']
           timeout = timeout.nil? ? 300 : timeout.to_i
         end
+        host = '127.0.0.1' if (host.nil?)
         port = 3001 if (port.nil? || port <= 0 || port > 65535)
 
         super do
           @pikelet_class.start if @pikelet_class.respond_to?(:start)
-          @server = ::WEBrick::HTTPServer.new(:Port => port, :BindAddress => '127.0.0.1',
+          @server = ::WEBrick::HTTPServer.new(:Port => port, :BindAddress => host,
             :AccessLog => [], :Logger => WEBrick::Log::new("/dev/null", 7))
           @server.mount "/", Rack::Handler::WEBrick, @pikelet_class
           yield @server if block_given?

--- a/spec/lib/flapjack/pikelet_spec.rb
+++ b/spec/lib/flapjack/pikelet_spec.rb
@@ -67,6 +67,7 @@ describe Flapjack::Pikelet, :logger => true do
   it "creates and starts a http server gateway" do
     expect(config).to receive(:[]).with('logger').and_return(nil)
     expect(config).to receive(:[]).with('max_runs').and_return(nil)
+    expect(config).to receive(:[]).with('bind_address').and_return('127.0.0.1')
     expect(config).to receive(:[]).with('port').and_return(7654)
     expect(config).to receive(:[]).with('timeout').and_return(90)
 
@@ -103,6 +104,7 @@ describe Flapjack::Pikelet, :logger => true do
     exc = RuntimeError.new
     expect(config).to receive(:[]).with('logger').and_return(nil)
     expect(config).to receive(:[]).with('max_runs').and_return(nil)
+    expect(config).to receive(:[]).with('bind_address').and_return('127.0.0.1')
     expect(config).to receive(:[]).with('port').and_return(7654)
     expect(config).to receive(:[]).with('timeout').and_return(90)
 


### PR DESCRIPTION
This is to avoid having the bind address hard-coded, and to make tasks like proxying easier.