### PR TITLE
use token authentication for pagerduty gateway

### DIFF
--- a/lib/flapjack/data/contact.rb
+++ b/lib/flapjack/data/contact.rb
@@ -160,7 +160,7 @@ module Flapjack
       def set_pagerduty_credentials(details)
         @redis.hset("contact_media:#{self.id}", 'pagerduty', details['service_key'])
         @redis.hmset("contact_pagerduty:#{self.id}",
-                     *['subdomain', 'username', 'password'].collect {|f| [f, details[f]]})
+                     *['subdomain', 'token'].collect {|f| [f, details[f]]})
       end
 
       def delete_pagerduty_credentials
@@ -498,7 +498,7 @@ module Flapjack
             when 'pagerduty'
               redis.hset("contact_media:#{contact_id}", medium, details['service_key'])
               redis.hmset("contact_pagerduty:#{contact_id}",
-                          *['subdomain', 'username', 'password'].collect {|f| [f, details[f]]})
+                          *['subdomain', 'token'].collect {|f| [f, details[f]]})
             else
               redis.hset("contact_media:#{contact_id}", medium, details['address'])
               redis.hset("contact_media_intervals:#{contact_id}", medium, details['interval']) if details['interval']

--- a/lib/flapjack/gateways/jsonapi/pagerduty_credential_methods.rb
+++ b/lib/flapjack/gateways/jsonapi/pagerduty_credential_methods.rb
@@ -30,7 +30,7 @@ module Flapjack
               halt err(422, "No valid pagerduty credentials were submitted")
             end
 
-            fields = ['service_key', 'subdomain', 'username', 'password']
+            fields = ['service_key', 'subdomain', 'token']
 
             pagerduty_credential = pagerduty_credentials_data.last
 
@@ -102,11 +102,8 @@ module Flapjack
                   when 'subdomain'
                     pd_data['subdomain'] = value
                     contact.set_pagerduty_credentials(pd_data)
-                  when 'username'
-                    pd_data['username'] = value
-                    contact.set_pagerduty_credentials(pd_data)
-                  when 'password'
-                    pd_data['password'] = value
+                  when 'token'
+                    pd_data['token'] = value
                     contact.set_pagerduty_credentials(pd_data)
                   end
                 end

--- a/lib/flapjack/gateways/pagerduty.rb
+++ b/lib/flapjack/gateways/pagerduty.rb
@@ -237,14 +237,13 @@ module Flapjack
 
       def pagerduty_acknowledged?(opts)
         subdomain   = opts['subdomain']
-        username    = opts['username']
-        password    = opts['password']
+        token       = opts['token']
         check       = opts['check']
 
-        unless subdomain && username && password && check
+        unless subdomain && token && check
           @logger.warn("pagerduty_acknowledged?: Unable to look for acknowledgements on pagerduty" +
                        " as all of the following options are required:" +
-                       " subdomain (#{subdomain}), username (#{username}), password (#{password}), check (#{check})")
+                       " subdomain (#{subdomain}), token (#{token}), check (#{check})")
           return nil
         end
 
@@ -257,7 +256,7 @@ module Flapjack
                   'incident_key' => check,
                   'status'       => 'acknowledged' }
 
-        options = { :head  => { 'authorization' => [username, password] },
+        options = { :head  => { 'authorization' => "Token token=#{token}" },
                     :query => query }
 
         @logger.debug("pagerduty_acknowledged?: request to #{url}")

--- a/spec/lib/flapjack/data/contact_spec.rb
+++ b/spec/lib/flapjack/data/contact_spec.rb
@@ -39,8 +39,7 @@ describe Flapjack::Data::Contact, :redis => true do
           'pagerduty' => {
             'service_key' => '123456789012345678901234',
             'subdomain'   => 'flpjck',
-            'username'    => 'flapjack',
-            'password'    => 'very_secure'
+            'token'       => 'token123'
           },
         },
       },
@@ -277,22 +276,19 @@ describe Flapjack::Data::Contact, :redis => true do
     expect(credentials).to be_a(Hash)
     expect(credentials).to eq({'service_key' => '123456789012345678901234',
                            'subdomain'   => 'flpjck',
-                           'username'    => 'flapjack',
-                           'password'    => 'very_secure'})
+                           'token'       => 'token123'})
   end
 
   it "sets pagerduty credentials for a contact" do
     contact = Flapjack::Data::Contact.find_by_id('c362', :redis => @redis)
     contact.set_pagerduty_credentials('service_key' => '567890123456789012345678',
                                       'subdomain'   => 'eggs',
-                                      'username'    => 'flapjack',
-                                      'password'    => 'tomato')
+                                      'token'       => 'token123')
 
     expect(@redis.hget('contact_media:c362', 'pagerduty')).to eq('567890123456789012345678')
     expect(@redis.hgetall('contact_pagerduty:c362')).to eq({
       'subdomain'   => 'eggs',
-      'username'    => 'flapjack',
-      'password'    => 'tomato'
+      'token'       => 'token123'
     })
   end
 

--- a/spec/lib/flapjack/gateways/jsonapi/pagerduty_credential_methods_spec.rb
+++ b/spec/lib/flapjack/gateways/jsonapi/pagerduty_credential_methods_spec.rb
@@ -10,8 +10,7 @@ describe 'Flapjack::Gateways::JSONAPI::PagerdutyCredentialMethods', :sinatra => 
   let(:pagerduty_credentials) {
     {'service_key' => 'abc',
      'subdomain'   => 'def',
-     'username'    => 'ghi',
-     'password'    => 'jkl',
+     'token'       => 'ghi'
     }
   }
 

--- a/spec/lib/flapjack/gateways/pagerduty_spec.rb
+++ b/spec/lib/flapjack/gateways/pagerduty_spec.rb
@@ -69,7 +69,7 @@ describe Flapjack::Gateways::Pagerduty, :logger => true do
     stub_request(:get, "https://flpjck.pagerduty.com/api/v1/incidents?" +
       "fields=incident_number,status,last_status_change_by&incident_key=#{check}&" +
       "since=#{since}&status=acknowledged&until=#{unt}").
-       with(:headers => {'Authorization'=>['flapjack', 'password123']}).
+       with(:headers => {'Authorization'=>'Token token=token123'}).
        to_return(:status => 200, :body => response.to_json, :headers => {})
 
     expect(Flapjack::RedisPool).to receive(:new).and_return(redis)
@@ -77,8 +77,8 @@ describe Flapjack::Gateways::Pagerduty, :logger => true do
 
 
     EM.synchrony do
-      result = fp.send(:pagerduty_acknowledged?, 'subdomain' => 'flpjck', 'username' => 'flapjack',
-        'password' => 'password123', 'check' => check)
+      result = fp.send(:pagerduty_acknowledged?, 'subdomain' => 'flpjck', 'token' => 'token123',
+        'check' => check)
 
       expect(result).to be_a(Hash)
       expect(result).to have_key(:pg_acknowledged_by)
@@ -98,8 +98,7 @@ describe Flapjack::Gateways::Pagerduty, :logger => true do
     expect(contact).to receive(:pagerduty_credentials).and_return({
       'service_key' => '12345678',
       'subdomain"'  => 'flpjck',
-      'username'    => 'flapjack',
-      'password'    => 'password123'
+      'token'       => 'token123'
     })
 
     entity_check = double('entity_check')
@@ -192,7 +191,6 @@ describe Flapjack::Gateways::Pagerduty, :logger => true do
 
   it "does not look for acknowledgements if all required credentials are not present" do
     creds = {'subdomain' => 'example',
-             'username'  => 'sausage',
              'check'     => 'PING'}
 
     expect(Flapjack::RedisPool).to receive(:new).and_return(redis)

--- a/spec/service_consumers/pacts/flapjack-diner_v1.0.json
+++ b/spec/service_consumers/pacts/flapjack-diner_v1.0.json
@@ -18,8 +18,8 @@
         "body": [
           {
             "op": "replace",
-            "path": "/pagerduty_credentials/0/password",
-            "value": "pswrd"
+            "path": "/pagerduty_credentials/0/token",
+            "value": "token123"
           }
         ]
       },
@@ -47,8 +47,8 @@
         "body": [
           {
             "op": "replace",
-            "path": "/pagerduty_credentials/0/password",
-            "value": "pswrd"
+            "path": "/pagerduty_credentials/0/token",
+            "value": "token123"
           }
         ]
       },
@@ -71,8 +71,8 @@
         "body": [
           {
             "op": "replace",
-            "path": "/pagerduty_credentials/0/password",
-            "value": "pswrd"
+            "path": "/pagerduty_credentials/0/token",
+            "value": "token123"
           }
         ]
       },
@@ -147,8 +147,7 @@
             {
               "service_key": "abc",
               "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
+              "token": "ghi"
             }
           ]
         }
@@ -177,8 +176,7 @@
             {
               "service_key": "abc",
               "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
+              "token": "ghi"
             }
           ]
         }
@@ -212,14 +210,12 @@
             {
               "service_key": "abc",
               "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
+              "token": "ghi"
             },
             {
               "service_key": "mno",
               "subdomain": "pqr",
-              "username": "stu",
-              "password": "vwx"
+              "token": "stu"
             }
           ]
         }
@@ -261,8 +257,7 @@
             {
               "service_key": "abc",
               "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
+              "token": "ghi"
             }
           ]
         }
@@ -285,8 +280,7 @@
             {
               "service_key": "abc",
               "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
+              "token": "ghi"
             }
           ]
         }

--- a/spec/service_consumers/provider_states_for_flapjack-diner.rb
+++ b/spec/service_consumers/provider_states_for_flapjack-diner.rb
@@ -301,8 +301,7 @@ Pact.provider_states_for "flapjack-diner" do
       pdc_data = {
         'service_key' => 'abc',
         'subdomain'   => 'def',
-        'username'    => 'ghi',
-        'password'    => 'jkl',
+        'token'       => 'ghi',
       }
       contact.set_pagerduty_credentials(pdc_data)
     end
@@ -333,15 +332,13 @@ Pact.provider_states_for "flapjack-diner" do
       pdc_data = {
         'service_key' => 'abc',
         'subdomain'   => 'def',
-        'username'    => 'ghi',
-        'password'    => 'jkl',
+        'token'       => 'ghi',
       }
       contact.set_pagerduty_credentials(pdc_data)
       pdc_data_2 = {
         'service_key' => 'mno',
         'subdomain'   => 'pqr',
-        'username'    => 'stu',
-        'password'    => 'vwx',
+        'token'       => 'stu',
     }
     contact_2.set_pagerduty_credentials(pdc_data_2)
     end


### PR DESCRIPTION
on June 16, 2014, PagerDuty [announced](https://developer.pagerduty.com/release_notes) that _Basic Authentication_ was being deprecated.

these changes remove using `username` and `password` for communicating with [PagerDuty REST API](https://developer.pagerduty.com/) in favor of `token`. more details about how PagerDuty API authentication works can be found [here](https://developer.pagerduty.com/documentation/rest/authentication).

- update gateway to set `Authorization` header using `token` (available via credentials) instead of `username` and `password`.
- update `jsonapi` to remove `username` and `password` in favor of `token`.
- update `contact` to remove `username` and `password` in favor of `token`.
- update consumer specs to work with token rather than `username` and `password`.
- update specs to work with the changes above.

i am also going to create a pull request for [flapjack-diner](https://github.com/flapjack/flapjack-diner).