### PR TITLE
remove disabled checks from rollup calculations

### DIFF
--- a/features/rollup.feature
+++ b/features/rollup.feature
@@ -176,6 +176,52 @@ Feature: Rollup on a per contact, per media basis
     And   1 sms alert of type problem and rollup problem should be queued for +61400000001
 
   @time
+  Scenario: Disabling a failing check suppresses rollup
+    Given check 'ping' for entity 'foo' is in an ok state
+    And   check 'ping' for entity 'baz' is in an ok state
+    When  a critical event is received for check 'ping' on entity 'foo'
+    And   1 minute passes
+    And   a critical event is received for check 'ping' on entity 'foo'
+    Then  1 sms alert should be queued for +61400000001
+    Then  1 sms alerts of type problem and rollup none should be queued for +61400000001
+    When  5 minutes passes
+    And   a critical event is received for check 'ping' on entity 'baz'
+    And   1 minute passes
+    And   a critical event is received for check 'ping' on entity 'baz'
+    Then  1 sms alert of type problem and rollup problem should be queued for +61400000001
+    And   2 sms alerts should be queued for +61400000001
+    When  check 'ping' on entity 'foo' is disabled
+    And   30 minutes passes
+    And   a critical event is received for check 'ping' on entity 'baz'
+    Then  1 sms alert of rollup recovery should be queued for +61400000001
+
+  @time
+  Scenario: Enabling a failing check promotes rollup
+    Given check 'ping' for entity 'foo' is in an ok state
+    And   check 'ping' for entity 'baz' is in an ok state
+    When  a critical event is received for check 'ping' on entity 'foo'
+    And   1 minute passes
+    And   a critical event is received for check 'ping' on entity 'foo'
+    Then  1 sms alert should be queued for +61400000001
+    Then  1 sms alert of type problem and rollup none should be queued for +61400000001
+    When  check 'ping' for entity 'foo' is disabled
+    And   5 minutes passes
+    And   a critical event is received for check 'ping' on entity 'baz'
+    And   1 minute passes
+    And   a critical event is received for check 'ping' on entity 'baz'
+    Then  2 sms alerts should be queued for +61400000001
+    Then  1 sms alert of type problem and rollup none should be queued for +61400000001
+    Then  1 sms alert of type problem and rollup recovery should be queued for +61400000001
+    When  1 hour passes
+    And   check 'ping' on entity 'foo' is enabled
+    And   5 minutes passes
+    And   a critical event is received for check 'ping' on entity 'foo'
+    Then  3 sms alerts should be queued for +61400000001
+    Then  1 sms alert of type problem and rollup none should be queued for +61400000001
+    Then  1 sms alert of type problem and rollup recovery should be queued for +61400000001
+    And   1 sms alert of type problem and rollup problem should be queued for +61400000001
+
+  @time
   Scenario: Contact ceases to be a contact on an entity that they were being alerted for
     Given check 'ping' for entity 'foo' is in an ok state
     And   check 'ping' for entity 'baz' is in an ok state

--- a/features/steps/events_steps.rb
+++ b/features/steps/events_steps.rb
@@ -279,6 +279,16 @@ When /^the unscheduled maintenance is ended(?: for check '([\w\.\-]+)' on entity
   end_unscheduled_maintenance(entity, check)
 end
 
+When /^check '([\w\.\-]+)' (?:for|on) entity '([\w\.\-]+)' is (dis|en)abled$/ do |check, entity, dis_en|
+  entity_check = Flapjack::Data::EntityCheck.for_entity_name(entity, check, :redis => @redis)
+  case dis_en
+  when 'dis'
+    entity_check.disable!
+  when 'en'
+    entity_check.enable!
+  end
+end
+
 # TODO logging is a side-effect, should test for notification generation itself
 Then /^a notification should not be generated(?: for check '([\w\.\-]+)' on entity '([\w\.\-]+)')?$/ do |check, entity|
   check  ||= @check

--- a/lib/flapjack/data/entity_check.rb
+++ b/lib/flapjack/data/entity_check.rb
@@ -681,7 +681,6 @@ module Flapjack
         @redis.zadd("all_checks:#{entity_name}", timestamp, check)
         @redis.zrem("current_checks:#{entity_name}", check)
         if @redis.zcount("current_checks:#{entity_name}", '-inf', '+inf') == 0
-          @redis.zrem("current_checks:#{entity_name}", check)
           @redis.zrem("current_entities", entity.name)
         end
       end

--- a/lib/flapjack/data/notification.rb
+++ b/lib/flapjack/data/notification.rb
@@ -221,8 +221,8 @@ module Flapjack
             contact.add_alerting_check_for_media(media, @event_id) unless ok? || acknowledgement? || test?
 
             # expunge checks in (un)scheduled maintenance from the alerting set
-            cleaned = contact.clean_alerting_checks_for_media(media)
-            logger.debug("cleaned alerting checks for #{media}: #{cleaned}")
+            recovered = contact.clean_alerting_checks_for_media(media)
+            logger.debug("cleaned alerting checks for #{media}: recovered? #{recovered}")
 
             # pagerduty is an example of a medium which should never be rolled up
             unless ['pagerduty'].include?(media)
@@ -236,7 +236,7 @@ module Flapjack
                 next ret if contact.drop_rollup_notifications_for_media?(media)
                 contact.update_sent_rollup_alert_keys_for_media(media, :delete => ok?)
                 rollup_type = 'problem'
-              when (alerting_checks + cleaned) >= rollup_threshold
+              when recovered
                 # alerting checks was just cleaned such that it is now below the rollup threshold
                 contact.update_sent_rollup_alert_keys_for_media(media, :delete => true)
                 rollup_type = 'recovery'

--- a/lib/flapjack/redis_pool.rb
+++ b/lib/flapjack/redis_pool.rb
@@ -32,6 +32,8 @@ module Flapjack
         Flapjack::Data::Migration.refresh_archive_index(:redis => redis)
         Flapjack::Data::Migration.validate_scheduled_maintenance_periods(:redis => redis,
           :logger => logger)
+        Flapjack::Data::Migration.correct_rollup_including_disabled_checks(:redis => redis,
+          :logger => logger)
         redis
       }
     end

--- a/spec/lib/flapjack/redis_pool_spec.rb
+++ b/spec/lib/flapjack/redis_pool_spec.rb
@@ -18,6 +18,7 @@ describe Flapjack::RedisPool do
       expect(Flapjack::Data::Migration).to receive(:clear_orphaned_entity_ids).exactly(redis_count).times
       expect(Flapjack::Data::Migration).to receive(:refresh_archive_index).exactly(redis_count).times
       expect(Flapjack::Data::Migration).to receive(:validate_scheduled_maintenance_periods).exactly(redis_count).times
+      expect(Flapjack::Data::Migration).to receive(:correct_rollup_including_disabled_checks).exactly(redis_count).times
 
       frp = Flapjack::RedisPool.new(:size => redis_count)
 


### PR DESCRIPTION
This may trigger rollup recovery erroneously, as seen in the cucumber features in this PR. (This has always been the case with the rollup code in Flapjack v1, as rollup is based only around whether the count is exceeded, and not whether a rollup notification has been sent out -- in `master`, this is stored as an explicit state on the medium object to avoid this problem).