### PR TITLE
Puma rather than Webrick, plus exception requests are now logged in the access_log

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
       ice_cube
       mail
       oj (>= 2.9.0)
+      puma
       rbtrace
       redis (>= 3.0.7)
       sinatra
@@ -71,13 +72,13 @@ GEM
       rspec (>= 2.0, < 4.0)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mime-types (2.4.3)
-    minitest (5.6.0)
+    mime-types (2.5)
+    minitest (5.6.1)
     msgpack (0.5.11)
     multi_json (1.11.0)
     multi_test (0.1.2)
     numerizer (0.1.1)
-    oj (2.12.4)
+    oj (2.12.5)
     pact (1.7.0)
       awesome_print (~> 1.1)
       find_a_port (~> 1.0.1)
@@ -109,6 +110,8 @@ GEM
       rspec (>= 2.14)
       term-ansicolor (~> 1.0)
       thor
+    puma (2.11.2)
+      rack (>= 1.1, < 2.0)
     rack (1.6.0)
     rack-protection (1.5.3)
       rack
@@ -145,7 +148,7 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    swagger-blocks (1.1.1)
+    swagger-blocks (1.1.2)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     terminal-table (1.4.5)
@@ -158,7 +161,7 @@ GEM
     trollop (2.1.2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2015.3)
+    tzinfo-data (1.2015.4)
       tzinfo (>= 1.0.0)
     webmock (1.21.0)
       addressable (>= 2.3.6)

--- a/flapjack.gemspec
+++ b/flapjack.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rbtrace'
   gem.add_dependency 'terminal-table'
   gem.add_dependency 'toml-rb'
+  gem.add_dependency 'puma'
 
   gem.add_development_dependency 'rake'
 end

--- a/lib/flapjack/gateways/jsonapi/helpers/headers.rb
+++ b/lib/flapjack/gateways/jsonapi/helpers/headers.rb
@@ -40,19 +40,24 @@ module Flapjack
               }
             }
 
-            [status_code, headers, Flapjack.dump_json(error_data)]
+            # Rack::CommonLogger doesn't log requests which result in exceptions.
+            # If you want something done properly, do it yourself...
+            result = Flapjack.dump_json(error_data)
+            access_log = self.class.instance_variable_get('@middleware').detect {|mw|
+              mw.first.is_a?(::Rack::CommonLogger)
+            }
+            unless access_log.nil?
+              access_log.first.send(:log, status_code,
+                ::Rack::Utils::HeaderHash.new(headers), result,
+                env['request_timestamp'])
+            end
+            [status_code, headers, result]
           end
 
           def is_jsonapi_request?
             return false if request.content_type.nil?
             Flapjack::Gateways::JSONAPI::JSONAPI_MEDIA_TYPE.eql?(request.content_type.split(/\s*[;,]\s*/, 2).first)
           end
-
-          # def is_jsonpatch_request?
-          #   return false if request.content_type.nil?
-          #   'application/json-patch+json'.eql?(request.content_type.split(/\s*[;,]\s*/, 2).first)
-          # end
-
         end
       end
     end

--- a/lib/flapjack/gateways/jsonapi/middleware/array_param_fixer.rb
+++ b/lib/flapjack/gateways/jsonapi/middleware/array_param_fixer.rb
@@ -7,7 +7,7 @@ require 'rack'
 module Flapjack
   module Gateways
     class JSONAPI < Sinatra::Base
-      module Rack
+      module Middleware
         class ArrayParamFixer < Struct.new(:app)
           def call(env)
             if (env["REQUEST_METHOD"] == 'GET') && env["rack.request.query_string"].nil?

--- a/lib/flapjack/gateways/jsonapi/middleware/json_params_parser.rb
+++ b/lib/flapjack/gateways/jsonapi/middleware/json_params_parser.rb
@@ -5,7 +5,7 @@ require 'rack'
 module Flapjack
   module Gateways
     class JSONAPI < Sinatra::Base
-      module Rack
+      module Middleware
         class JsonParamsParser < Struct.new(:app)
           def call(env)
             t = type(env)

--- a/lib/flapjack/gateways/jsonapi/middleware/request_timestamp.rb
+++ b/lib/flapjack/gateways/jsonapi/middleware/request_timestamp.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require 'rack'
+
+module Flapjack
+  module Gateways
+    class JSONAPI < Sinatra::Base
+      module Middleware
+        class RequestTimestamp < Struct.new(:app)
+          def call(env)
+            env['request_timestamp'] = Time.now
+            app.call(env)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/flapjack/gateways/web.rb
+++ b/lib/flapjack/gateways/web.rb
@@ -3,7 +3,7 @@
 require 'chronic'
 require 'chronic_duration'
 require 'sinatra/base'
-require 'erb'
+require 'tilt/erb'
 require 'uri'
 
 require 'flapjack/redis_proxy'
@@ -13,34 +13,42 @@ require 'flapjack/data/check'
 require 'flapjack/data/event'
 require 'flapjack/utility'
 
+require 'flapjack/gateways/web/middleware/request_timestamp'
+
 module Flapjack
 
   module Gateways
 
     class Web < Sinatra::Base
 
-      set :raise_errors, true
+      set :root, File.dirname(__FILE__)
+
+      use Flapjack::Gateways::JSONAPI::Middleware::RequestTimestamp
+      use Rack::MethodOverride
+
+      set :raise_errors, false
       set :protection, except: :path_traversal
 
       set :views, settings.root + '/web/views'
       set :public_folder, settings.root + '/web/public'
 
-      use Rack::MethodOverride
-
       class << self
         def start
           Flapjack.logger.info "starting web - class"
 
-          set :show_exceptions, @config['show_exceptions'].is_a?(TrueClass)
+          set :show_exceptions, false
+          # set :show_exceptions, @config['show_exceptions'].is_a?(TrueClass) ? :after_handler : false
 
-          if accesslog = (@config && @config['access_log'])
-            if not File.directory?(File.dirname(accesslog))
-              puts "Parent directory for log file #{accesslog} doesn't exist"
-              puts "Exiting!"
-              exit
+          @show_exceptions = Sinatra::ShowExceptions.new(self)
+
+          if access_log = (@config && @config['access_log'])
+            if not File.directory?(File.dirname(access_log))
+              raise "Parent directory for log file #{access_log} doesn't exist"
             end
 
-            use Rack::CommonLogger, ::Logger.new(@config['access_log'])
+            @access_log = ::Logger.new(@config['access_log'])
+
+            use Rack::CommonLogger, @access_log
           end
 
           @api_url = @config['api_url']
@@ -381,6 +389,24 @@ module Flapjack
         end
 
         erb 'contact.html'.to_sym
+      end
+
+      error do
+        e = env['sinatra.error']
+        # trace = e.backtrace.join("\n")
+        # puts trace
+
+        # Rack::CommonLogger doesn't log requests which result in exceptions.
+        # If you want something done properly, do it yourself...
+        access_log = self.class.instance_variable_get('@middleware').detect {|mw|
+          mw.first.is_a?(::Rack::CommonLogger)
+        }
+        unless access_log.nil?
+          access_log.first.send(:log, status_code,
+            ::Rack::Utils::HeaderHash.new(headers), msg,
+            env['request_timestamp'])
+        end
+        self.class.instance_variable_get('@show_exceptions').pretty(env, e)
       end
 
     private

--- a/lib/flapjack/gateways/web/middleware/request_timestamp.rb
+++ b/lib/flapjack/gateways/web/middleware/request_timestamp.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require 'rack'
+
+module Flapjack
+  module Gateways
+    class Web < Sinatra::Base
+      module Middleware
+        class RequestTimestamp < Struct.new(:app)
+          def call(env)
+            env['request_timestamp'] = Time.now
+            app.call(env)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/flapjack/pikelet.rb
+++ b/lib/flapjack/pikelet.rb
@@ -10,7 +10,7 @@
 
 require 'monitor'
 
-require 'webrick'
+require 'puma'
 
 require 'flapjack'
 
@@ -174,18 +174,17 @@ module Flapjack
 
         super do
           @pikelet_class.start if @pikelet_class.respond_to?(:start)
-          @server = ::WEBrick::HTTPServer.new(:Port => port, :BindAddress => bind_address,
-            :AccessLog => [], :Logger => WEBrick::Log::new("/dev/null", 7))
-          @server.mount "/", Rack::Handler::WEBrick, @pikelet_class
+          @server = ::Puma::Server.new(@pikelet_class)
+          @server.binder.add_tcp_listener(bind_address, port)
           yield @server if block_given?
-          @server.start
+          @server.run(false) # no background run, use current thread
         end
       end
 
       # this should only reload if all changes can be applied -- will
       # return false to log warning otherwise
       def reload(cfg)
-         # TODO fail if port changes
+         # TODO handle bind_address/port changes by changing listeners?
         return false unless @pikelet_class.respond_to?(:reload)
         super(cfg) { @pikelet_class.reload(cfg) }
       end
@@ -194,7 +193,7 @@ module Flapjack
         super do |thread|
           unless @server.nil?
             Flapjack.logger.info "shutting down server"
-            @server.shutdown
+            @server.stop(true)  # no background stop, wait for requests to finish
             Flapjack.logger.info "shut down server"
           end
           @pikelet_class.stop(thread) if @pikelet_class.respond_to?(:stop)

--- a/spec/lib/flapjack/gateways/web_spec.rb
+++ b/spec/lib/flapjack/gateways/web_spec.rb
@@ -164,7 +164,7 @@ describe Flapjack::Gateways::Web, :sinatra => true, :logger => true do
 
     it "shows the state of a check" do
       time = Time.now
-      expect(Time).to receive(:now).and_return(time)
+      expect(Time).to receive(:now).at_least(:once).and_return(time)
 
       expect_check_stats
       expect(Flapjack::Data::Check).to receive(:all).and_return([check])

--- a/spec/lib/flapjack/pikelet_spec.rb
+++ b/spec/lib/flapjack/pikelet_spec.rb
@@ -76,13 +76,14 @@ describe Flapjack::Pikelet, :logger => true do
     expect(lock).to receive(:synchronize).and_yield
     expect(Monitor).to receive(:new).and_return(lock)
 
+    binder = double('binder')
+    expect(binder).to receive(:add_tcp_listener).with('127.0.0.1', 7654)
+
     server = double('server')
-    expect(server).to receive(:mount).with('/', Rack::Handler::WEBrick,
-      Flapjack::Gateways::Web)
-    expect(server).to receive(:start)
-    expect(WEBrick::HTTPServer).to receive(:new).
-      with(:Port => 7654, :BindAddress => '127.0.0.1',
-           :AccessLog => [], :Logger => an_instance_of(::WEBrick::Log)).
+    expect(server).to receive(:binder).and_return(binder)
+    expect(server).to receive(:run).with(false)
+
+    expect(::Puma::Server).to receive(:new).with(Flapjack::Gateways::Web).
       and_return(server)
 
     expect(Flapjack::Gateways::Web).to receive(:instance_variable_set).
@@ -113,13 +114,14 @@ describe Flapjack::Pikelet, :logger => true do
     expect(lock).to receive(:synchronize).and_yield
     expect(Monitor).to receive(:new).and_return(lock)
 
+    binder = double('binder')
+    expect(binder).to receive(:add_tcp_listener).with('127.0.0.1', 7654)
+
     server = double('server')
-    expect(server).to receive(:mount).with('/', Rack::Handler::WEBrick,
-      Flapjack::Gateways::Web)
-    expect(server).to receive(:start).and_raise(exc)
-    expect(WEBrick::HTTPServer).to receive(:new).
-      with(:Port => 7654, :BindAddress => '127.0.0.1',
-           :AccessLog => [], :Logger => an_instance_of(::WEBrick::Log)).
+    expect(server).to receive(:binder).and_return(binder)
+    expect(server).to receive(:run).with(false).and_raise(exc)
+
+    expect(::Puma::Server).to receive(:new).with(Flapjack::Gateways::Web).
       and_return(server)
 
     expect(Flapjack::Gateways::Web).to receive(:instance_variable_set).


### PR DESCRIPTION
Fixes #794.

(A brief aside to curse Rack and Sinatra, which made this harder than it needed to be, and the code hackier.)