### PR TITLE
expose failure delays in web UI

### DIFF
--- a/lib/flapjack/gateways/web.rb
+++ b/lib/flapjack/gateways/web.rb
@@ -289,8 +289,6 @@ module Flapjack
         entity_check = get_entity_check(@entity, @check)
         halt(404, "Could not find check '#{@entity}:#{@check}'") if entity_check.nil?
 
-        check_stats
-
         last_change = entity_check.last_change
 
         @check_state                = entity_check.state
@@ -300,6 +298,14 @@ module Flapjack
         @check_summary              = entity_check.summary
         @check_details              = entity_check.details
         @check_perfdata             = entity_check.perfdata
+
+        @check_initial_failure_delay = entity_check.initial_failure_delay ||
+          Flapjack::DEFAULT_INITIAL_FAILURE_DELAY
+        @check_repeat_failure_delay  = entity_check.repeat_failure_delay  ||
+          Flapjack::DEFAULT_REPEAT_FAILURE_DELAY
+
+        @check_initial_failure_delay_is_default = entity_check.initial_failure_delay ? false : true
+        @check_repeat_failure_delay_is_default  = entity_check.repeat_failure_delay  ? false : true
 
         @last_notifications         = last_notification_data(entity_check)
 

--- a/lib/flapjack/gateways/web/views/check.html.erb
+++ b/lib/flapjack/gateways/web/views/check.html.erb
@@ -279,6 +279,32 @@
 </div><!-- row -->
 
 <div class="row">
+  <div id="failure-delays" class="col-md-6">
+    <a name="failure_delays"></a>
+    <h3>Failure Delays</h3>
+    <table class="table table-hover table-condensed">
+
+      <tr>
+        <td>Initial failure delay:</td>
+        <td><%= h(ChronicDuration.output(@check_initial_failure_delay, :keep_zero => true)) %>
+          <% if @check_initial_failure_delay_is_default %>
+            (default)
+          <% end %>
+        </td>
+      </tr>
+      <tr>
+        <td>Repeat failure delay:</td>
+        <td><%= h(ChronicDuration.output(@check_repeat_failure_delay, :keep_zero => true)) %>
+          <% if @check_repeat_failure_delay_is_default %>
+            (default)
+          <% end %>
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+<div class="row">
   <div id="scheduled-maintenance-periods" class="col-md-12">
     <a name="scheduled_maintenance_periods"></a>
     <h3>Scheduled Maintenance Periods</h3>

--- a/spec/lib/flapjack/gateways/web/views/check.html.erb_spec.rb
+++ b/spec/lib/flapjack/gateways/web/views/check.html.erb_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'chronic_duration'
 
 describe 'web/views/check.html.erb', :erb_view => true do
 
@@ -8,6 +9,10 @@ describe 'web/views/check.html.erb', :erb_view => true do
     @entity = 'abc-xyz-01'
     @check  = 'Disk / Utilisation'
     @last_notifications = {}
+    @check_initial_failure_delay = 30
+    @check_repeat_failure_delay  = 60
+    @check_initial_failure_delay_is_default = true
+    @check_repeat_failure_delay_is_default  = true
 
     page = render_erb('check.html.erb', binding)
     expect(page).to match(%r{/abc-xyz-01/Disk%20%2F%20Utilisation})

--- a/spec/lib/flapjack/gateways/web_spec.rb
+++ b/spec/lib/flapjack/gateways/web_spec.rb
@@ -175,7 +175,6 @@ describe Flapjack::Gateways::Web, :sinatra => true, :logger => true do
                             :recovery        => {:timestamp => time.to_i - (3 * 60 * 60), :summary => nil},
                             :acknowledgement => {:timestamp => nil, :summary => nil} }
 
-      expect_check_stats
       expect(entity_check).to receive(:state).and_return('ok')
       expect(entity_check).to receive(:last_update).and_return(time.to_i - (3 * 60 * 60))
       expect(entity_check).to receive(:last_change).and_return(time.to_i - (3 * 60 * 60))
@@ -191,6 +190,8 @@ describe Flapjack::Gateways::Web, :sinatra => true, :logger => true do
       expect(entity_check).to receive(:historical_states).
         with(nil, time.to_i, :order => 'desc', :limit => 20).and_return([])
       expect(entity_check).to receive(:enabled?).and_return(true)
+      expect(entity_check).to receive(:initial_failure_delay).exactly(2).times.and_return(30)
+      expect(entity_check).to receive(:repeat_failure_delay).exactly(2).times.and_return(60)
 
       expect(Flapjack::Data::Entity).to receive(:find_by_name).
         with(entity_name, :redis => redis).and_return(entity)


### PR DESCRIPTION
Includes info about whether the value is derived from the flapjack defaults or not. 

![screenshot 2015-05-05 21 41 08](https://cloud.githubusercontent.com/assets/391439/7472949/8ab09bb0-f376-11e4-8d70-8e6f92f1735d.png)
