### PR TITLE
fixes #847 - fall back to basic auth for pagerduty incidents api

### DIFF
--- a/lib/flapjack/data/contact.rb
+++ b/lib/flapjack/data/contact.rb
@@ -160,7 +160,7 @@ module Flapjack
       def set_pagerduty_credentials(details)
         @redis.hset("contact_media:#{self.id}", 'pagerduty', details['service_key'])
         @redis.hmset("contact_pagerduty:#{self.id}",
-                     *['subdomain', 'token'].collect {|f| [f, details[f]]})
+                     *['subdomain', 'token', 'username', 'password'].collect {|f| [f, details[f]]})
       end
 
       def delete_pagerduty_credentials
@@ -506,7 +506,7 @@ module Flapjack
             when 'pagerduty'
               redis.hset("contact_media:#{contact_id}", medium, details['service_key'])
               redis.hmset("contact_pagerduty:#{contact_id}",
-                          *['subdomain', 'token'].collect {|f| [f, details[f]]})
+                          *['subdomain', 'token', 'username', 'password'].collect {|f| [f, details[f]]})
             else
               redis.hset("contact_media:#{contact_id}", medium, details['address'])
               redis.hset("contact_media_intervals:#{contact_id}", medium, details['interval']) if details['interval']

--- a/lib/flapjack/gateways/jsonapi/pagerduty_credential_methods.rb
+++ b/lib/flapjack/gateways/jsonapi/pagerduty_credential_methods.rb
@@ -30,7 +30,7 @@ module Flapjack
               halt err(422, "No valid pagerduty credentials were submitted")
             end
 
-            fields = ['service_key', 'subdomain', 'token']
+            fields = ['service_key', 'subdomain', 'token', 'username', 'password']
 
             pagerduty_credential = pagerduty_credentials_data.last
 
@@ -104,6 +104,12 @@ module Flapjack
                     contact.set_pagerduty_credentials(pd_data)
                   when 'token'
                     pd_data['token'] = value
+                    contact.set_pagerduty_credentials(pd_data)
+                  when 'username'
+                    pd_data['username'] = value
+                    contact.set_pagerduty_credentials(pd_data)
+                  when 'password'
+                    pd_data['password'] = value
                     contact.set_pagerduty_credentials(pd_data)
                   end
                 end

--- a/lib/flapjack/gateways/pagerduty.rb
+++ b/lib/flapjack/gateways/pagerduty.rb
@@ -238,12 +238,15 @@ module Flapjack
       def pagerduty_acknowledged?(opts)
         subdomain   = opts['subdomain']
         token       = opts['token']
+        username    = opts['username']
+        password    = opts['password']
         check       = opts['check']
 
-        unless subdomain && token && check
+        unless subdomain && (token || (username && password)) && check
           @logger.warn("pagerduty_acknowledged?: Unable to look for acknowledgements on pagerduty" +
-                       " as all of the following options are required:" +
-                       " subdomain (#{subdomain}), token (#{token}), check (#{check})")
+                       " as the following options are required:" +
+                       " subdomain (#{subdomain}), token (#{token}) or" +
+                       " username (#{username}) and password (#{password}), check (#{check})")
           return nil
         end
 
@@ -256,7 +259,13 @@ module Flapjack
                   'incident_key' => check,
                   'status'       => 'acknowledged' }
 
-        options = { :head  => { 'authorization' => "Token token=#{token}" },
+        auth_header = if token && token.length > 0
+          "Token token=#{token}"
+        else
+          [username, password]
+        end
+
+        options = { :head  => { 'authorization' => auth_header },
                     :query => query }
 
         @logger.debug("pagerduty_acknowledged?: request to #{url}")
@@ -294,4 +303,3 @@ module Flapjack
   end
 
 end
-

--- a/spec/lib/flapjack/data/contact_spec.rb
+++ b/spec/lib/flapjack/data/contact_spec.rb
@@ -39,7 +39,9 @@ describe Flapjack::Data::Contact, :redis => true do
           'pagerduty' => {
             'service_key' => '123456789012345678901234',
             'subdomain'   => 'flpjck',
-            'token'       => 'token123'
+            'token'       => 'token123',
+            'username'    => nil,
+            'password'    => nil
           },
         },
       },
@@ -275,20 +277,26 @@ describe Flapjack::Data::Contact, :redis => true do
     expect(credentials).not_to be_nil
     expect(credentials).to be_a(Hash)
     expect(credentials).to eq({'service_key' => '123456789012345678901234',
-                           'subdomain'   => 'flpjck',
-                           'token'       => 'token123'})
+                               'subdomain'   => 'flpjck',
+                               'token'       => 'token123',
+                               'username'    => '',
+                               'password'    => ''})
   end
 
   it "sets pagerduty credentials for a contact" do
     contact = Flapjack::Data::Contact.find_by_id('c362', :redis => @redis)
     contact.set_pagerduty_credentials('service_key' => '567890123456789012345678',
                                       'subdomain'   => 'eggs',
-                                      'token'       => 'token123')
+                                      'token'       => 'token123',
+                                      'username'    => 'mary',
+                                      'password'    => 'mary_password')
 
     expect(@redis.hget('contact_media:c362', 'pagerduty')).to eq('567890123456789012345678')
     expect(@redis.hgetall('contact_pagerduty:c362')).to eq({
       'subdomain'   => 'eggs',
-      'token'       => 'token123'
+      'token'       => 'token123',
+      'username'    => 'mary',
+      'password'    => 'mary_password'
     })
   end
 

--- a/spec/lib/flapjack/gateways/jsonapi/pagerduty_credential_methods_spec.rb
+++ b/spec/lib/flapjack/gateways/jsonapi/pagerduty_credential_methods_spec.rb
@@ -10,7 +10,9 @@ describe 'Flapjack::Gateways::JSONAPI::PagerdutyCredentialMethods', :sinatra => 
   let(:pagerduty_credentials) {
     {'service_key' => 'abc',
      'subdomain'   => 'def',
-     'token'       => 'ghi'
+     'token'       => 'ghi',
+     'username'    => 'mongoose',
+     'password'    => 'mongoose_password'
     }
   }
 


### PR DESCRIPTION
I haven't updated flapjack-diner yet so the pact specs will still need updating when that happens. But I think this should be OK to merge if all the tests pass. 