### PR TITLE
2.0 restore subdomain for pagerduty ack retrievals - fixes #855

### DIFF
--- a/lib/flapjack/data/medium.rb
+++ b/lib/flapjack/data/medium.rb
@@ -27,6 +27,7 @@ module Flapjack
                         :address                => :string,
                         :interval               => :integer,
                         :rollup_threshold       => :integer,
+                        :pagerduty_subdomain    => :string,
                         :pagerduty_token        => :string,
                         :pagerduty_ack_duration => :integer,
                         :last_rollup_type       => :string
@@ -63,6 +64,9 @@ module Flapjack
         record.errors.add(att, 'must be nil') unless value.nil?
       end
 
+      validates :pagerduty_subdomain, :presence => true,
+        :if => proc {|m| 'pagerduty'.eql?(m.transport) }
+
       validates :pagerduty_token, :presence => true,
         :if => proc {|m| 'pagerduty'.eql?(m.transport) }
 
@@ -70,9 +74,8 @@ module Flapjack
         :numericality => {:greater_than => 0, :only_integer => true},
         :if => proc {|m| 'pagerduty'.eql?(m.transport) }
 
-      validates_each :pagerduty_token, :pagerduty_ack_duration,
+      validates_each :pagerduty_subdomain, :pagerduty_token, :pagerduty_ack_duration,
         :unless =>  proc {|m| 'pagerduty'.eql?(m.transport) } do |record, att, value|
-
         record.errors.add(att, 'must be nil') unless value.nil?
       end
 
@@ -120,6 +123,9 @@ module Flapjack
         property :rollup_threshold do
           key :type, :integer
           key :minimum, 1
+        end
+        property :pagerduty_subdomain do
+          key :type, :string
         end
         property :pagerduty_token do
           key :type, :string
@@ -179,6 +185,9 @@ module Flapjack
           key :type, :integer
           key :minimum, 1
         end
+        property :pagerduty_subdomain do
+          key :type, :string
+        end
         property :pagerduty_token do
           key :type, :string
         end
@@ -215,6 +224,9 @@ module Flapjack
         property :rollup_threshold do
           key :type, :integer
           key :minimum, 1
+        end
+        property :pagerduty_subdomain do
+          key :type, :string
         end
         property :pagerduty_token do
           key :type, :string

--- a/lib/flapjack/gateways/pager_duty.rb
+++ b/lib/flapjack/gateways/pager_duty.rb
@@ -204,6 +204,7 @@ module Flapjack
 
               Kernel.sleep 10
             end
+          end
 
           # ensure
           #   Flapjack.redis.quit

--- a/lib/flapjack/gateways/pager_duty.rb
+++ b/lib/flapjack/gateways/pager_duty.rb
@@ -192,7 +192,7 @@ module Flapjack
           loop do
             @lock.synchronize do
               # ensure we're the only instance of the PagerDuty acknowledgement check running (with a naive
-              # timeout of five minutes to guard against stale locks caused by crashing code) either in this
+              # timeout of one hour to guard against stale locks caused by crashing code) either in this
               # process or in other processes
               if Flapjack.redis.setnx(SEM_PAGERDUTY_ACKS_RUNNING, 'true') == 0
                 Flapjack.logger.debug("skipping looking for acks in PagerDuty as this is already happening")


### PR DESCRIPTION
fixes #855 

subdomain is required by the pagerduty incidents api. it was removed in PR #821 