### PR TITLE
1.x pagerduty ack retrieval improvements

### DIFF
--- a/lib/flapjack/gateways/pagerduty.rb
+++ b/lib/flapjack/gateways/pagerduty.rb
@@ -202,12 +202,6 @@ module Flapjack
           # FIXME: try each set of credentials until one works (may have stale contacts turning up)
           options = ec_credentials.first.merge('check' => "#{entity_name}:#{check}")
 
-          acknowledged = pagerduty_acknowledged?(options)
-          if acknowledged.nil?
-            @logger.debug "#{entity_name}:#{check} is not acknowledged in pagerduty, skipping"
-            next
-          end
-
           # check again that the check is still unacknowledged
           if entity_check.in_unscheduled_maintenance?
             # skip this one
@@ -221,6 +215,12 @@ module Flapjack
             # skip this one
             @logger.warn "#{entity_name}:#{check} seems to have recovered " +
               "while I've been running. Cancelling acknowledgement creation"
+            next
+          end
+
+          acknowledged = pagerduty_acknowledged?(options)
+          if acknowledged.nil?
+            @logger.debug "#{entity_name}:#{check} is not acknowledged in pagerduty, skipping"
             next
           end
 

--- a/spec/lib/flapjack/gateways/pagerduty_spec.rb
+++ b/spec/lib/flapjack/gateways/pagerduty_spec.rb
@@ -142,13 +142,15 @@ describe Flapjack::Gateways::Pagerduty, :logger => true do
     })
 
     entity_check = double('entity_check')
-    expect(entity_check).to receive(:check).exactly(2).times.and_return('PING')
+    expect(entity_check).to receive(:check).exactly(1).times.and_return('PING')
     expect(entity_check).to receive(:contacts).and_return([contact])
-    expect(entity_check).to receive(:entity_name).exactly(2).times.and_return('foo-app-01.bar.net')
+    expect(entity_check).to receive(:entity_name).exactly(1).times.and_return('foo-app-01.bar.net')
+    expect(entity_check).to receive(:in_unscheduled_maintenance?).exactly(1).times.and_return(false)
+    expect(entity_check).to receive(:failed?).exactly(1).times.and_return(true)
     expect(Flapjack::Data::Event).to receive(:create_acknowledgement).with('foo-app-01.bar.net', 'PING',
       :summary => 'Acknowledged on PagerDuty', :duration => 14400, :redis => redis)
 
-    expect(Flapjack::Data::EntityCheck).to receive(:unacknowledged_failing).exactly(2).times.and_return([entity_check])
+    expect(Flapjack::Data::EntityCheck).to receive(:unacknowledged_failing).exactly(1).times.and_return([entity_check])
 
     expect(fp).to receive(:pagerduty_acknowledged?).and_return({})
 

--- a/spec/lib/flapjack/gateways/pagerduty_spec.rb
+++ b/spec/lib/flapjack/gateways/pagerduty_spec.rb
@@ -32,7 +32,7 @@ describe Flapjack::Gateways::Pagerduty, :logger => true do
   it "looks for acknowledgements if the search is not already running" do
     expect(redis).to receive(:get).with('sem_pagerduty_acks_running').and_return(nil)
     expect(redis).to receive(:set).with('sem_pagerduty_acks_running', 'true')
-    expect(redis).to receive(:expire).with('sem_pagerduty_acks_running', 300)
+    expect(redis).to receive(:expire).with('sem_pagerduty_acks_running', 3600)
 
     expect(redis).to receive(:del).with('sem_pagerduty_acks_running')
 


### PR DESCRIPTION
This increases the expiry on pagerduty acks running semaphore to 1 hour. 

Should address #854 in a fairly terrible kind of way. 