### PR TITLE
Check for incidents in both acknowledged or resolved states to show as acknowleged in flapjack

### DIFF
--- a/lib/flapjack/gateways/pagerduty.rb
+++ b/lib/flapjack/gateways/pagerduty.rb
@@ -257,7 +257,7 @@ module Flapjack
                   'since'        => (t - (60*60*24*7)).iso8601, # the last week
                   'until'        => (t + (60*60*24)).iso8601,   # 1 day in the future
                   'incident_key' => check,
-                  'status'       => 'acknowledged' }
+                  'status'       => 'acknowledged,resolved' }
 
         auth_header = if token && token.length > 0
           "Token token=#{token}"

--- a/spec/lib/flapjack/gateways/pagerduty_spec.rb
+++ b/spec/lib/flapjack/gateways/pagerduty_spec.rb
@@ -68,7 +68,7 @@ describe Flapjack::Gateways::Pagerduty, :logger => true do
 
     stub_request(:get, "https://flpjck.pagerduty.com/api/v1/incidents?" +
       "fields=incident_number,status,last_status_change_by&incident_key=#{check}&" +
-      "since=#{since}&status=acknowledged&until=#{unt}").
+      "since=#{since}&status=acknowledged,resolved&until=#{unt}").
        with(:headers => {'Authorization'=>'Token token=token123'}).
        to_return(:status => 200, :body => response.to_json, :headers => {})
 
@@ -109,7 +109,7 @@ describe Flapjack::Gateways::Pagerduty, :logger => true do
 
     stub_request(:get, "https://flpjck.pagerduty.com/api/v1/incidents?" +
       "fields=incident_number,status,last_status_change_by&incident_key=#{check}&" +
-      "since=#{since}&status=acknowledged&until=#{unt}").
+      "since=#{since}&status=acknowledged,resolved&until=#{unt}").
       with(:headers => {'Authorization'=>['flapjack', 'password123']}).
       to_return(:status => 200, :body => response.to_json, :headers => {})
 


### PR DESCRIPTION
When an alert is acknowledged in PagerDuty, an ack is sent back to Flapjack.

However, this currently does not occur if the alert is already resolved in Flapjack at the time that it polls.

This fixes that by checking for alerts in both acknowledged and resolved states.