### PR TITLE
Manually escaping "+" as "%20", because amazon won't accept "+".

### DIFF
--- a/lib/flapjack/gateways/aws_sns.rb
+++ b/lib/flapjack/gateways/aws_sns.rb
@@ -159,12 +159,14 @@ module Flapjack
       end
 
       def self.string_to_sign(method, host, uri, query)
-        query = query.sort_by { |key, value| key }
+
+        escaped_q = Addressable::URI.form_encode(query,sort=true)
+        escaped_q.gsub!('+','%20')
 
         [method.upcase,
          host.downcase,
          uri,
-         URI.encode_www_form(query)
+         escaped_q
         ].join("\n")
       end
 


### PR DESCRIPTION
SNS notifications fail because URI.encode_www_form encodes spaces as plus-sign. Amazon requires spaces be percent-encoded.

Possibly fixes https://github.com/flapjack/flapjack/issues/829