### PR TITLE
SNS query encoding and subject length

### DIFF
--- a/lib/flapjack/gateways/aws_sns.rb
+++ b/lib/flapjack/gateways/aws_sns.rb
@@ -142,12 +142,18 @@ module Flapjack
       end
 
       def self.string_to_sign(method, host, uri, query)
+        @safe_re ||= Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")
+
+        encoded_query = query.keys.sort.collect {|key|
+          "#{key}=#{URI.escape(query[key].to_s, @safe_re)}"
+        }.join("&")
+
         query = query.sort_by { |key, value| key }
 
         [method.upcase,
          host.downcase,
          uri,
-         URI.encode_www_form(query)
+         encoded_query
         ].join("\n")
       end
 

--- a/lib/flapjack/gateways/aws_sns/alert_subject.text.erb
+++ b/lib/flapjack/gateways/aws_sns/alert_subject.text.erb
@@ -1,0 +1,4 @@
+<%= @alert.type_sentence_case %>: '<%= @alert.check %>' on <%= @alert.entity -%>
+<% unless ['acknowledgement', 'test'].include?(@alert.notification_type) -%>
+ is <%= @alert.state_title_case -%>
+<% end -%>

--- a/lib/flapjack/gateways/aws_sns/rollup_subject.text.erb
+++ b/lib/flapjack/gateways/aws_sns/rollup_subject.text.erb
@@ -1,0 +1,1 @@
+<%= @alert.type_sentence_case %>: <%= @alert.rollup_states_summary -%>

--- a/spec/lib/flapjack/gateways/aws_sns_spec.rb
+++ b/spec/lib/flapjack/gateways/aws_sns_spec.rb
@@ -53,6 +53,28 @@ describe Flapjack::Gateways::AwsSns, :logger => true do
     expect(req).to have_been_requested
   end
 
+  it 'truncates an overly long subject when sending' do
+    req = stub_request(:post, "http://sns.us-east-1.amazonaws.com/").
+      with(:query => hash_including({'Action'           => 'Publish',
+                                     'AWSAccessKeyId'   => config['access_key'],
+                                     'TopicArn'         => message['address'],
+                                     'SignatureVersion' => '2',
+                                     'SignatureMethod'  => 'HmacSHA256',
+                                     'Subject'          => "Recovery: '#{'1234567890' * 8}123456..."})).
+      to_return(:status => 200)
+
+    EM.synchrony do
+      expect(Flapjack::RedisPool).to receive(:new).and_return(redis)
+
+      long_event_id = "example.com:#{'1234567890' * 10}"
+      alert = Flapjack::Data::Alert.new(message.merge('event_id' => long_event_id), :logger => @logger)
+      aws_sns = Flapjack::Gateways::AwsSns.new(:config => config, :logger => @logger)
+      aws_sns.deliver(alert)
+      EM.stop
+    end
+    expect(req).to have_been_requested
+  end
+
   it "does not send an SMS message with an invalid config" do
     EM.synchrony do
       expect(Flapjack::RedisPool).to receive(:new).and_return(redis)

--- a/spec/lib/flapjack/gateways/aws_sns_spec.rb
+++ b/spec/lib/flapjack/gateways/aws_sns_spec.rb
@@ -75,7 +75,8 @@ describe Flapjack::Gateways::AwsSns, :logger => true do
     let(:uri) { '/' }
 
     let(:query) { {'TopicArn' => 'HelloWorld',
-                  'Action' => 'Publish'} }
+                   'Action' => 'Publish',
+                   'Message' => 'Hello World'} }
 
     let(:string_to_sign) { Flapjack::Gateways::AwsSns.string_to_sign(method, host, uri, query) }
 
@@ -94,7 +95,7 @@ describe Flapjack::Gateways::AwsSns, :logger => true do
     end
 
     it 'should put the encoded, sorted query-string on the fourth line' do
-      expect(lines[3]).to eq("Action=Publish&TopicArn=HelloWorld")
+      expect(lines[3]).to eq("Action=Publish&Message=Hello%20World&TopicArn=HelloWorld")
     end
 
   end


### PR DESCRIPTION
See #829 and #865.

A more comprehensive URI encoding cleanup using `addressable` would be good, maybe after 2.0.