### PR TITLE
Fixed encoding of query to generate proper signature

### DIFF
--- a/lib/flapjack/gateways/aws_sns.rb
+++ b/lib/flapjack/gateways/aws_sns.rb
@@ -149,13 +149,12 @@ module Flapjack
 
         Base64.encode64(signature).strip
       end
-
+      def self.url_encode(string)
+        # don't encode: ~_-, spaces must be %20
+        CGI.escape(string.to_s).gsub("%7E", "~").gsub("+", "%20")
+      end
       def self.string_to_sign(method, host, uri, query)
-        @safe_re ||= Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")
-
-        encoded_query = query.keys.sort.collect {|key|
-          "#{URI.escape(key, @safe_re)}=#{URI.escape(query[key].to_s, @safe_re)}"
-        }.join("&")
+        encoded_query = query.keys.sort.collect {|key|  [self.url_encode(key), self.url_encode(query[key])].join("=") }.join("&")
 
         [method.upcase,
          host.downcase,
@@ -167,4 +166,3 @@ module Flapjack
     end
   end
 end
-


### PR DESCRIPTION
This fixes the issue referenced in #829.  Was a result of improper encoding of the query prior to being sent out for signature.