### PR TITLE
fixes #869: add summary to rollup_alerts

### DIFF
--- a/lib/flapjack/gateways/email/rollup.html.erb
+++ b/lib/flapjack/gateways/email/rollup.html.erb
@@ -22,16 +22,19 @@
       <th>Entity</th>
       <th>State</th>
       <th>Duration</th>
+      <th>Summary</th>
     </tr>
 <%  @alert.rollup_alerts.sort_by {|entity_check, details| details['duration'] }.each do |rollup_alert| -%>
 <%    r_entity, r_check = rollup_alert[0].split(':', 2) -%>
 <%    state    = rollup_alert[1]['state'] -%>
 <%    duration = (ChronicDuration.output(rollup_alert[1]['duration'], :keep_zero => true) || '0 secs') -%>
+<%    summary = rollup_alert[1]['summary'] -%>
       <tr>
         <td><%= r_check %></td>
         <td><%= r_entity %></td>
         <td><%= ['ok'].include?(state) ? state.upcase : state.titleize %></td>
         <td><%= duration %></td>
+        <td><%= summary %></td>
       </tr>
 <%    end %>
   </tbody>

--- a/lib/flapjack/notifier.rb
+++ b/lib/flapjack/notifier.rb
@@ -119,7 +119,8 @@ module Flapjack
             last_change = ec.last_change
             memo[alert] = {
               'duration' => last_change ? (Time.now.to_i - last_change) : nil,
-              'state'    => ec.state
+              'state'    => ec.state,
+              'summary'  => ec.summary
             }
             memo
           end


### PR DESCRIPTION
Adds access to the summary in the rollup alert notification templates. 