### PR TITLE
Fix notification rule regex matches

### DIFF
--- a/lib/flapjack/data/notification_rule.rb
+++ b/lib/flapjack/data/notification_rule.rb
@@ -128,7 +128,7 @@ module Flapjack
         @entities.include?(event_entity)
       end
 
-      # If the rule has any regex_entities, then at least one of them must match the
+      # If the rule has any regex_entities, then all of them must match the
       # event's entity
       def match_regex_entities?(event_id)
         return true unless @regex_entities && @regex_entities.length > 0
@@ -137,7 +137,7 @@ module Flapjack
         @regex_entities.each do |regex_entity|
           matches += 1 if /#{regex_entity}/ === event_entity
         end
-        matches >= 1
+        matches >= @regex_entities.length
       end
 
       # If the rule has any tags, then they must all be present in the

--- a/lib/flapjack/data/notification_rule.rb
+++ b/lib/flapjack/data/notification_rule.rb
@@ -121,37 +121,39 @@ module Flapjack
         Flapjack.dump_json(json_data)
       end
 
-      # entity names match?
+      # If the rule has any entities, then one of them must match the event's entity
       def match_entity?(event_id)
-        return false unless @entities
-        @entities.include?(event_id.split(':').first)
+        return true unless @entities && @entities.length > 0
+        event_entity = event_id.split(':').first
+        @entities.include?(event_entity)
       end
 
-      # entity names match regex?
+      # If the rule has any regex_entities, then at least one of them must match the
+      # event's entity
       def match_regex_entities?(event_id)
-        return false unless @regex_entities && @regex_entities.length > 0
-        entity = event_id.split(':').first
+        return true unless @regex_entities && @regex_entities.length > 0
+        event_entity = event_id.split(':').first
         matches = 0
         @regex_entities.each do |regex_entity|
-          matches += 1 if /#{regex_entity}/ === entity
+          matches += 1 if /#{regex_entity}/ === event_entity
         end
-        matches >= @regex_entities.length
+        matches >= 1
       end
 
-      # tags match?
+      # If the rule has any tags, then they must all be present in the
+      # event's tags
       def match_tags?(event_tags)
-        return false unless @tags && @tags.length > 0
+        return true unless @tags && @tags.length > 0
         @tags.subset?(event_tags)
       end
 
-      # regex_tags match?
+      # If the rule has any regex_tags, then they must all match at least
+      # one of the event's tags
       def match_regex_tags?(event_tags)
-        return false unless @regex_tags && @regex_tags.length > 0
+        return true unless @regex_tags && @regex_tags.length > 0
         matches = 0
-        event_tags.each do |event_tag|
-          @regex_tags.each do |regex_tag|
-            matches += 1 if /#{regex_tag}/ === event_tag
-          end
+        @regex_tags.each do |regex_tag|
+          matches += 1 if event_tags.any? { |event_tag| /#{regex_tag}/ === event_tag }
         end
         matches >= @regex_tags.length
       end

--- a/spec/lib/flapjack/data/notification_rule_spec.rb
+++ b/spec/lib/flapjack/data/notification_rule_spec.rb
@@ -16,7 +16,23 @@ describe Flapjack::Data::NotificationRule, :redis => true do
     {:contact_id         => '23',
      :tags               => ["database","physical"],
      :regex_tags         => [],
-     :entities           => ["foo-app-01.example.com"],
+     :entities           => ["foo-app-01.example.com", "foo-app-10.example.com"],
+     :regex_entities     => [],
+     :time_restrictions  => [ weekdays_8_18 ],
+     :unknown_media      => [],
+     :warning_media      => ["email"],
+     :critical_media     => ["sms", "email"],
+     :unknown_blackhole  => false,
+     :warning_blackhole  => false,
+     :critical_blackhole => false
+    }
+  }
+
+  let(:empty_rule_data) {
+    {:contact_id         => '23',
+     :tags               => [],
+     :regex_tags         => [],
+     :entities           => [],
      :regex_entities     => [],
      :time_restrictions  => [ weekdays_8_18 ],
      :unknown_media      => [],
@@ -33,7 +49,7 @@ describe Flapjack::Data::NotificationRule, :redis => true do
      :tags               => [],
      :regex_tags         => ["^data.*$","^(physical|bare_metal)$"],
      :entities           => [],
-     :regex_entities     => ["^foo-\S{3}-\d{2}.example.com$"],
+     :regex_entities     => ['^foo-\S{3}-\d{2}.example.com$','^bar-\S{3}.example.com'],
      :time_restrictions  => [ weekdays_8_18 ],
      :unknown_media      => [],
      :warning_media      => ["email"],
@@ -50,6 +66,10 @@ describe Flapjack::Data::NotificationRule, :redis => true do
 
   let(:existing_rule) {
     Flapjack::Data::NotificationRule.add(rule_data, :redis => @redis)
+  }
+
+  let(:existing_empty_rule) {
+    Flapjack::Data::NotificationRule.add(empty_rule_data, :redis => @redis)
   }
 
   let(:existing_regex_rule) {
@@ -100,25 +120,47 @@ describe Flapjack::Data::NotificationRule, :redis => true do
     rule = existing_rule
 
     expect(rule.match_entity?('foo-app-01.example.com')).to be true
+    expect(rule.match_entity?('foo-app-10.example.com')).to be true
     expect(rule.match_entity?('foo-app-02.example.com')).to be false
+
+    expect(existing_empty_rule.match_entity?('anything.example.com')).to be true
   end
 
-  it "checks whether entity tags match" do
+  it "checks whether entity names match a regex" do
+    rule = existing_regex_rule
+
+    expect(rule.match_regex_entities?('foo-app-01.example.com')).to be true
+    expect(rule.match_regex_entities?('foo-app-11.example.com')).to be true
+    expect(rule.match_regex_entities?('foo-other.example.com')).to be false
+    expect(rule.match_regex_entities?('bar-app.example.com')).to be true
+    expect(rule.match_regex_entities?('bar-other.example.com')).to be false
+
+    expect(existing_empty_rule.match_regex_entities?('anything.example.com')).to be true
+  end
+
+  it "checks whether event tags match" do
     rule = existing_rule
 
     expect(rule.match_tags?(['database', 'physical'].to_set)).to be true
     expect(rule.match_tags?(['database', 'physical', 'beetroot'].to_set)).to be true
     expect(rule.match_tags?(['database'].to_set)).to be false
     expect(rule.match_tags?(['virtual'].to_set)).to be false
+    expect(rule.match_tags?([].to_set)).to be false
+
+    expect(existing_empty_rule.match_regex_entities?(['virtual'].to_set)).to be true
   end
 
-  it "checks whether entity tags match a regex" do
+  it "checks whether event tags match a regex" do
     rule = existing_regex_rule
 
     expect(rule.match_regex_tags?(['database', 'physical'].to_set)).to be true
     expect(rule.match_regex_tags?(['database', 'physical', 'beetroot'].to_set)).to be true
     expect(rule.match_regex_tags?(['database'].to_set)).to be false
+    expect(rule.match_regex_tags?(['database.physical'].to_set)).to be false # does not match second regex_tags
+    expect(rule.match_regex_tags?(['data1', 'data2'].to_set)).to be false # does not match second regex_tags
     expect(rule.match_regex_tags?(['virtual'].to_set)).to be false
+
+    expect(existing_empty_rule.match_regex_entities?(['virtual'].to_set)).to be true
   end
 
   it "checks if blackhole settings for a rule match a severity level" do

--- a/spec/lib/flapjack/data/notification_rule_spec.rb
+++ b/spec/lib/flapjack/data/notification_rule_spec.rb
@@ -49,7 +49,7 @@ describe Flapjack::Data::NotificationRule, :redis => true do
      :tags               => [],
      :regex_tags         => ["^data.*$","^(physical|bare_metal)$"],
      :entities           => [],
-     :regex_entities     => ['^foo-\S{3}-\d{2}.example.com$','^bar-\S{3}.example.com'],
+     :regex_entities     => ['^foo-\S{3}-\d{2}.example.com$','.*abc.*'],
      :time_restrictions  => [ weekdays_8_18 ],
      :unknown_media      => [],
      :warning_media      => ["email"],
@@ -129,11 +129,11 @@ describe Flapjack::Data::NotificationRule, :redis => true do
   it "checks whether entity names match a regex" do
     rule = existing_regex_rule
 
-    expect(rule.match_regex_entities?('foo-app-01.example.com')).to be true
-    expect(rule.match_regex_entities?('foo-app-11.example.com')).to be true
-    expect(rule.match_regex_entities?('foo-other.example.com')).to be false
-    expect(rule.match_regex_entities?('bar-app.example.com')).to be true
-    expect(rule.match_regex_entities?('bar-other.example.com')).to be false
+    expect(rule.match_regex_entities?('foo-abc-01.example.com')).to be true
+    expect(rule.match_regex_entities?('foo-abc-99.example.com')).to be true
+    expect(rule.match_regex_entities?('foo-app-01.example.com')).to be false # does not match second regexp_entities
+    expect(rule.match_regex_entities?('foo-abc.example.com')).to be false
+    expect(rule.match_regex_entities?('bar-abc-01.example.com')).to be false
 
     expect(existing_empty_rule.match_regex_entities?('anything.example.com')).to be true
   end


### PR DESCRIPTION
* Align with the specification of Notification Routing
* Fix the match_regex_entities to succeed if at least one regex_entity
  matches. Used to succeed only when all the regex_entity match,
  which makes no sense.
* Fix the match_regex_tags. The old implementation was counting
  how many pairs of regex_tags and event tags match, which
  can be an overestimate of how many regex_tags match.
* Added test for match_regex_tags (none before)