### PR TITLE
Preserve newline when displaying check summaries

### DIFF
--- a/lib/flapjack/gateways/email/alert.html.erb
+++ b/lib/flapjack/gateways/email/alert.html.erb
@@ -35,14 +35,14 @@
     <% if @alert.summary %>
       <tr>
         <td><strong>Summary</strong></td>
-        <td><%= @alert.summary %></td>
+        <td><pre><%= @alert.summary %></pre></td>
       </tr>
     <% end %>
 
     <% if @alert.details %>
       <tr>
         <td><strong>Details</strong></td>
-        <td><%= @alert.details %></td>
+        <td><pre><%= @alert.details %></pre></td>
       </tr>
     <% end %>
 
@@ -70,7 +70,7 @@
     <% if @alert.last_summary %>
       <tr>
         <td><strong>Previous Summary</strong></td>
-        <td><%= @alert.last_summary %></td>
+        <td><pre><%= @alert.last_summary %></pre></td>
       </tr>
     <% end %>
 

--- a/lib/flapjack/gateways/email/rollup.html.erb
+++ b/lib/flapjack/gateways/email/rollup.html.erb
@@ -34,7 +34,7 @@
         <td><%= r_entity %></td>
         <td><%= ['ok'].include?(state) ? state.upcase : state.titleize %></td>
         <td><%= duration %></td>
-        <td><%= summary %></td>
+        <td><pre><%= summary %></pre></td>
       </tr>
 <%    end %>
   </tbody>

--- a/lib/flapjack/gateways/web/public/css/flapjack.css
+++ b/lib/flapjack/gateways/web/public/css/flapjack.css
@@ -1,0 +1,8 @@
+
+div.check_summary {
+    /* The div used to display the check summaries.
+       We assume that the check output may contain newlines, which we want to preserve,
+       but we also want wrapping when required by the layout.
+    */
+    white-space: pre-line; /* Like pre, except it also wraps when necessary, and collapses consecutive whitespace */
+}

--- a/lib/flapjack/gateways/web/views/check.html.erb
+++ b/lib/flapjack/gateways/web/views/check.html.erb
@@ -218,7 +218,8 @@
 
 <div class="row">
   <div id="output" class="col-md-6">
-    <h3>Output: <%= h @check_summary %></h3>
+    <h3>Output:</h3>
+    <div class='check_summary'><%= h @check_summary %></div>
     <p><%= h @check_details %></p>
     <% if @check_perfdata && @check_perfdata.is_a?(Array) %>
     <h3>Performance Data:</h3>
@@ -249,7 +250,7 @@
           <td>Last <%= h type.to_s %> notification:</td>
           <td><%= @last_notifications[type] ? h(@last_notifications[type][:relative]) : 'never' %></td>
           <td><%= @last_notifications[type] ? h(@last_notifications[type][:time].to_s) : '&nbsp;' %></td>
-          <td><%= @last_notifications[type] ? h(@last_notifications[type][:summary]) : '&nbsp;' %></td>
+          <td><div class='check_summary'><%= @last_notifications[type] ? h(@last_notifications[type][:summary]) : '&nbsp;' %></div></td>
         </tr>
       <% end %>
     </table>
@@ -268,7 +269,7 @@
       <tr>
         <td><%= h Time.at(state_change[:timestamp]).to_s %></td>
         <td><%= h state_change[:state] %></td>
-        <td><%= h state_change[:summary] %></td>
+        <td><div class='check_summary'><%= h state_change[:summary] %></div></td>
       </tr>
       <% end %>
     </table>

--- a/lib/flapjack/gateways/web/views/checks.html.erb
+++ b/lib/flapjack/gateways/web/views/checks.html.erb
@@ -50,7 +50,7 @@
             <% if in_unscheduled_outage%> (Ack'd)<% end %>
             <% if in_scheduled_outage %> (Sched)<% end %>
           </td>
-          <td><%= h summary %></td>
+          <td><div class='check_summary'><%= h summary %></div></td>
           <td><%= h changed %></td>
           <td><%= h updated %></td>
           <td><%= h notified %></td>

--- a/lib/flapjack/gateways/web/views/layout.erb
+++ b/lib/flapjack/gateways/web/views/layout.erb
@@ -3,6 +3,7 @@
   require_css 'screen'
   require_css 'font-awesome'
   require_css 'tablesort'
+  require_css 'flapjack'
 
   require_js  'jquery-1.10.2'
   require_js  'jquery.tablesorter'


### PR DESCRIPTION
Check summaries often have newlines that are significant. For example,
Nagios, or Sensu, plugin output is line-oriented. It would be useful to
obey these newlines when displaying the check output. We do not
want to just use <pre> because that prevents line wrapping. We use
"white-space: pre-line" instead, which preserves all the newlines
in the summary, and adds additional ones by wrapping when necessary to
fit in the enclosing UI elements.

In email templates, it seems that only the <pre> tag works reliably.