### PR TITLE
Fix rollup flood for recoveries

### DIFF
--- a/features/steps/events_steps.rb
+++ b/features/steps/events_steps.rb
@@ -185,7 +185,7 @@ Given /^(?:the check|check '([\w\.\-]+)' for entity '([\w\.\-]+)') is in unsched
   entity ||= @entity
   remove_scheduled_maintenance(entity, check)
   set_critical_state(entity, check)
-  submit_acknowledgement(entity, check)
+  one_event('acknowledgement', entity, check)
   drain_events  # TODO these should only be in When clauses
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -49,7 +49,9 @@ class MockLogger
   %w(debug info warn error fatal).each do |level|
     class_eval <<-RUBY
       def #{level}(msg)
+        # puts "#{level}: "+msg
         @messages << msg
+
       end
     RUBY
   end

--- a/lib/flapjack/data/notification.rb
+++ b/lib/flapjack/data/notification.rb
@@ -233,8 +233,11 @@ module Flapjack
               when rollup_threshold.nil?
                 # back away slowly
               when alerting_checks >= rollup_threshold
-                next ret if contact.drop_rollup_notifications_for_media?(media)
-                contact.update_sent_rollup_alert_keys_for_media(media, :delete => ok?)
+                if contact.drop_rollup_notifications_for_media?(media)
+                  logger.debug "rollup decisions: #{@event_id} #{@state} #{media} #{address} skip because in rollup mode"
+                  next ret
+                end
+                contact.update_sent_rollup_alert_keys_for_media(media, :delete => false)
                 rollup_type = 'problem'
               when recovered
                 # alerting checks was just cleaned such that it is now below the rollup threshold


### PR DESCRIPTION
* Fix rollup flood for recoveries
* This is related to #896: a series of 'ok' events in a rollup state is not summarized properly
* Also refactored some of the events steps for Cucumber tests
