### PR TITLE
Save tags for events, and show them in the UI

### DIFF
--- a/features/steps/events_steps.rb
+++ b/features/steps/events_steps.rb
@@ -95,7 +95,8 @@ def submit_ok(entity, check)
     'state'   => 'ok',
     'summary' => '0% packet loss',
     'entity'  => entity,
-    'check'   => check
+    'check'   => check,
+    'tags'    => [ 'tag1', 'tag2' ]
   }
   submit_event(event)
 end

--- a/lib/flapjack/gateways/web.rb
+++ b/lib/flapjack/gateways/web.rb
@@ -307,6 +307,9 @@ module Flapjack
         @check_initial_failure_delay_is_default = entity_check.initial_failure_delay ? false : true
         @check_repeat_failure_delay_is_default  = entity_check.repeat_failure_delay  ? false : true
 
+        tags_saved = entity_check.tags_saved
+        @tags = ( tags_saved.is_a?(Set) ? tags_saved.to_a : tags_saved ) || []
+
         @last_notifications         = last_notification_data(entity_check)
 
         @scheduled_maintenances     = entity_check.maintenances(nil, nil, :scheduled => true)

--- a/lib/flapjack/gateways/web/views/check.html.erb
+++ b/lib/flapjack/gateways/web/views/check.html.erb
@@ -305,6 +305,27 @@
 </div>
 
 <div class="row">
+  <div id="tags" class="col-md-6">
+    <a name="tags"></a>
+    <h3>Tags</h3>
+    <% if @tags && !@tags.empty? %>
+        <table class="table table-bordered table-hover table-condensed">
+          <tr>
+            <th>Tag</th>
+          </tr>
+          <% @tags.sort.each do |tag| %>
+              <tr>
+                <td><%= h tag %></td>
+              </tr>
+          <% end %>
+        </table>
+    <% else %>
+        <p>There are <strong>no tags</strong> associated with this check.</p>
+    <% end %>
+  </div>
+</div>
+
+<div class="row">
   <div id="scheduled-maintenance-periods" class="col-md-12">
     <a name="scheduled_maintenance_periods"></a>
     <h3>Scheduled Maintenance Periods</h3>

--- a/lib/flapjack/processor.rb
+++ b/lib/flapjack/processor.rb
@@ -228,7 +228,8 @@ module Flapjack
                                   :summary => event.summary, :count => event.counter,
                                   :details => event.details, :perfdata => event.perfdata,
                                   :initial_failure_delay => event.initial_failure_delay,
-                                  :repeat_failure_delay => event.repeat_failure_delay)
+                                  :repeat_failure_delay => event.repeat_failure_delay,
+                                  :tags => event.tags)
 
         entity_check.update_current_scheduled_maintenance
 


### PR DESCRIPTION
Since tags can play a big role in the notification routing, it is very useful to see in the UI the tags in the events. This change saves the tags when the event is processed, and passes them to the view for display. 