### PR TITLE
Hide PD token and service key

### DIFF
--- a/lib/flapjack/gateways/web/views/contact.html.erb
+++ b/lib/flapjack/gateways/web/views/contact.html.erb
@@ -25,7 +25,7 @@
           <td>
             <% @pagerduty_credentials.each_pair do |pk, pv| %>
               <% unless pv.empty? %>
-                <p><%= 'password'.eql?(pk) ? h("#{pk}: ...") : h("#{pk}: #{pv}") %></p>
+                <p><%= %w(password token service_key).include?(pk) ? h("#{pk}: ...") : h("#{pk}: #{pv}") %></p>
               <% end %>
             <% end %>
           </td>


### PR DESCRIPTION
This commit extends the credential hiding code already present for the PD password to the PD token and service key.  Resolves #909