### PR TITLE
Add a sleep inside the work loop to avoid error looping filling up the logs.

### DIFF
--- a/lib/flapjack/gateways/email.rb
+++ b/lib/flapjack/gateways/email.rb
@@ -56,6 +56,10 @@ module Flapjack
           rescue => e
             @logger.error "Error generating or dispatching email message: #{e.class}: #{e.message}\n" +
               e.backtrace.join("\n")
+
+            # Sleep 1-2 seconds to avoid pathologically reconnecting to Redis. (Issues/866)
+            # Random delay is intended as cheap stampeding herd mitigation
+            sleep(1 + rand())
           end
         end
       end


### PR DESCRIPTION
Related to #886, this PR adds a delay of 1-2 seconds in the exception handler of the email worker loop.  This should resolve the issues seen in #886 in the wild where logs are being filled with tightly looped connection requests, however there may be a more general location for this delay I haven't found.  This will only resolve pathological connection attempts from Flapjack::Gateways::Email.start.