### PR TITLE
Set Blather logger to the configured jabber logger

### DIFF
--- a/lib/flapjack/gateways/jabber.rb
+++ b/lib/flapjack/gateways/jabber.rb
@@ -47,6 +47,9 @@ module Flapjack
 
         @logger = opts[:logger]
 
+        # Log xmpp details using the gateway logger
+        Blather.logger = @logger
+
         @redis = Flapjack::RedisPool.new(:config => @redis_config, :size => 2, :logger => @logger)
 
         @logger.debug("Jabber Initializing")


### PR DESCRIPTION
This aids in debugging issues with XMPP, otherwise,
particularly when using SSL, is a nightmare.

The Blather debug logging is quite chatty, but, IMO
it's better to have a chatty debug option than a debug
option that doesn't really help debugging :)

I later stumbled upon issue #503 which faced the same problem I was having, but I only found it upon inspection of the XMPP logs produced by setting the Blather logging to debug and sent them to the flapjack log file