### PR TITLE
httpbroker event fields

### DIFF
--- a/libexec/httpbroker.go
+++ b/libexec/httpbroker.go
@@ -90,6 +90,8 @@ func submitCachedState(states map[string]State, config Config) {
 				Type:    state.Type,
 				State:   state.State,
 				Summary: state.Summary,
+				Details: state.Details,
+				Tags:    state.Tags,
 				Time:    now,
 			}
 

--- a/src/flapjack/event.go
+++ b/src/flapjack/event.go
@@ -5,12 +5,14 @@ import "errors"
 // Event is a basic representation of a Flapjack event.
 // Find more at http://flapjack.io/docs/1.0/development/DATA_STRUCTURES
 type Event struct {
-	Entity  string `json:"entity"`
-	Check   string `json:"check"`
-	Type    string `json:"type"`
-	State   string `json:"state"`
-	Summary string `json:"summary"`
-	Time    int64  `json:"time"`
+	Entity  string   `json:"entity"`
+	Check   string   `json:"check"`
+	Type    string   `json:"type"`
+	State   string   `json:"state"`
+	Time    int64    `json:"time"`
+	Summary string   `json:"summary"`
+	Details string   `json:"details"`
+	Tags    []string `json:"tags"`
 }
 
 // IsValid performs basic validations on the event data.

--- a/src/flapjack/event_test.go
+++ b/src/flapjack/event_test.go
@@ -24,3 +24,19 @@ func TestValidationPasses(t *testing.T) {
 		t.Error("Expected validation to pass, got:", err)
 	}
 }
+
+func TestValidationPassesExtraFields(t *testing.T) {
+	event := Event{
+		Entity:  "hello",
+		Check:   "world",
+		State:   "ok",
+		Summary: "hello world",
+		Details: "hello world, i am quite detailed",
+		Tags:    []string{"hello_world"},
+	}
+	err := event.IsValid()
+
+	if err != nil {
+		t.Error("Expected validation to pass, got:", err)
+	}
+}


### PR DESCRIPTION
Support ingestion of Tags and Details on inbound events.

We have been using tags as part of our notification_rules on contacts for sending specific events between teams. Tags are sent along with an event coming from our Sensu Server using a custom `flapjack_http.rb` extension handler, loosely based on the existing flapjack-redis extension handler.

Please let me know if a second PR should be rebased against master and submitted. We are still operating on 1.x, and this PR has finally unblocked our entire pipeline.