### PR TITLE
Extra broker config options, plus port details & tags field support from maint/1.x

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ go get gopkg.in/alecthomas/kingpin.v2
 go get github.com/oguzbilgic/pandik
 mv bin/pandik libexec/httpchecker
 
-if [ ! -z "$SKIPTESTS" ]; then
+if [ -z "$SKIPTESTS" ]; then
   go test flapjack
 fi
 

--- a/libexec/oneoff.go
+++ b/libexec/oneoff.go
@@ -11,23 +11,29 @@ import (
 )
 
 var (
-	app      = kingpin.New("oneoff", "Submits a single event to Flapjack.")
+	app = kingpin.New("oneoff", "Submits a single event to Flapjack.")
+
+	flapjack_version = app.Flag("flapjack-version", "Flapjack version being delivered to (1 or 2)").Default("2").Int()
+
 	entity   = app.Arg("entity", "Entity name").Required().String()
 	check    = app.Arg("check", "Check name").Required().String()
 	state    = app.Arg("state", "Current state").Required().String()
 	summary  = app.Arg("summary", "Summary of event").Required().String()
 	debug    = app.Flag("debug", "Enable verbose output (default false)").Bool()
-	server   = app.Flag("server", "Redis server to connect to (default localhost:6380)").Default("localhost:6380").String()
-	database = app.Flag("database", "Redis database to connect to (default 0)").Int()
+	server   = app.Flag("server", "Redis server to connect to").Default("localhost:6380").String()
+	database = app.Flag("database", "Redis database to connect to").Default("0").Int()
+	queue    = app.Flag("queue", "Flapjack event queue name to use").Default("events").String()
 )
 
 func main() {
-	app.Version("0.0.1")
+	app.Version("0.0.2")
 	app.Writer(os.Stdout) // direct help to stdout
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	app.Writer(os.Stderr) // ... but ensure errors go to stderr
 
 	if *debug {
+		fmt.Println("Flapjack version:", *flapjack_version)
+
 		fmt.Println("Entity:", *entity)
 		fmt.Println("Check:", *check)
 		fmt.Println("State:", *state)
@@ -35,6 +41,7 @@ func main() {
 		fmt.Println("Debug:", *debug)
 		fmt.Println("Server:", *server)
 		fmt.Println("Database:", *database)
+		fmt.Println("Queue:", *queue)
 	}
 
 	addr := strings.Split(*server, ":")
@@ -67,7 +74,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	reply, err := transport.Send(event)
+	reply, err := transport.Send(event, *flapjack_version, *queue)
+
 	if *debug {
 		fmt.Println("Reply from Redis:", reply)
 	}

--- a/src/flapjack/event.go
+++ b/src/flapjack/event.go
@@ -5,12 +5,14 @@ import "errors"
 // Event is a basic representation of a Flapjack event.
 // Find more at http://flapjack.io/docs/1.0/development/DATA_STRUCTURES
 type Event struct {
-	Entity  string `json:"entity"`
-	Check   string `json:"check"`
-	Type    string `json:"type"`
-	State   string `json:"state"`
-	Summary string `json:"summary"`
-	Time    int64  `json:"time"`
+	Entity  string   `json:"entity"`
+	Check   string   `json:"check"`
+	Type    string   `json:"type"`
+	State   string   `json:"state"`
+	Time    int64    `json:"time"`
+	Summary string   `json:"summary"`
+	Details string   `json:"details"`
+	Tags    []string `json:"tags"`
 }
 
 // IsValid performs basic validations on the event data.

--- a/src/flapjack/event_test.go
+++ b/src/flapjack/event_test.go
@@ -24,3 +24,19 @@ func TestValidationPasses(t *testing.T) {
 		t.Error("Expected validation to pass, got:", err)
 	}
 }
+
+func TestValidationPassesExtraFields(t *testing.T) {
+	event := Event{
+		Entity:  "hello",
+		Check:   "world",
+		State:   "ok",
+		Summary: "hello world",
+		Details: "hello world, i am quite detailed",
+		Tags:    []string{"hello_world"},
+	}
+	err := event.IsValid()
+
+	if err != nil {
+		t.Error("Expected validation to pass, got:", err)
+	}
+}

--- a/src/flapjack/transport.go
+++ b/src/flapjack/transport.go
@@ -32,21 +32,31 @@ func Dial(address string, database int) (Transport, error) {
 }
 
 // Send takes an event and sends it over a transport.
-func (t Transport) Send(event Event) (interface{}, error) {
+func (t Transport) Send(event Event, flapjackVersion int, list string) (interface{}, error) {
 	err := event.IsValid()
 	if err != nil {
 		return nil, err
 	}
 
 	data, _ := json.Marshal(event)
-	reply, err := t.Connection.Do("LPUSH", "events", data)
+	reply, err := t.Connection.Do("LPUSH", list, data)
 	if err != nil {
 		return nil, err
 	}
 
-	// required for Flapjack v2 -- if the broker is split out as a separate
-	// project, this will need to be optional
-	_, err = t.Connection.Do("LPUSH", "events_actions", "+")
+	if flapjackVersion >= 2 {
+		_, err := t.Connection.Do("LPUSH", list+"_actions", "+")
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return reply, nil
+}
+
+func (t Transport) Close() (interface{}, error) {
+	reply, err := t.Connection.Do("QUIT")
 	if err != nil {
 		return nil, err
 	}

--- a/src/flapjack/transport_test.go
+++ b/src/flapjack/transport_test.go
@@ -24,7 +24,7 @@ func TestSendSucceeds(t *testing.T) {
 		Summary: "hello world",
 	}
 
-	_, err = transport.Send(event)
+	_, err = transport.Send(event, 1, "events")
 	if err != nil {
 		t.Fatalf("Error when sending event: %s", err)
 	}
@@ -37,7 +37,7 @@ func TestSendFails(t *testing.T) {
 	}
 	event := Event{}
 
-	_, err = transport.Send(event)
+	_, err = transport.Send(event, 1, "events")
 	if err == nil {
 		t.Fatal("Expected error when sending event, got none.")
 	}


### PR DESCRIPTION
I think this changes the tags built currently in `master` from an associative array to a regular string array, but the second is what's documented, so anyone depending on the former will have to change tooling.

With the `flapjack_version` config arg, once this is merged I'll copy the broker and dependent code across to `maint/1.x`, changing the default in there to `1`.

A sanity check on this would be good, I wasn't expecting the change to be quite so large...