### PR TITLE
Added button to entity page to remove active scheduled maintenances

### DIFF
--- a/lib/flapjack/gateways/web.rb
+++ b/lib/flapjack/gateways/web.rb
@@ -386,6 +386,16 @@ module Flapjack
         redirect back
       end
 
+      # delete a scheduled maintenance for an entity
+      delete '/scheduled_maintenances/:entity' do
+        entity = get_entity(params[:entity])
+        
+        halt(404, "Could not find entity '#{params[:entity]}'") if entity.nil?
+
+        entity.end_scheduled_maintenance(:redis => redis)
+        redirect back
+      end 
+
       # delete a check (actually just disables it)
       delete '/checks/:entity/:check' do
         entity_check = get_entity_check(params[:entity], params[:check])
@@ -431,6 +441,11 @@ module Flapjack
           Flapjack::Data::Entity.find_by_name(entity, :redis => redis) : nil
         return if entity_obj.nil? || (check.nil? || check.length == 0)
         Flapjack::Data::EntityCheck.for_entity(entity_obj, check, :redis => redis)
+      end
+
+      def get_entity(entity)
+        entity_obj = (entity && entity.length > 0) ?
+          Flapjack::Data::Entity.find_by_name(entity, :redis => redis) : nil
       end
 
       def entity_check_state(entity_name, check)

--- a/lib/flapjack/gateways/web/views/entity.html.erb
+++ b/lib/flapjack/gateways/web/views/entity.html.erb
@@ -5,6 +5,10 @@
 
 <div class="page-header">
   <h2><%= h @entity %></h2>
+  <form action="<%= @base_url %>scheduled_maintenances/<%= @entity %>" method="post" align="right">
+    <input type="hidden" name="_method" value="delete">
+    <button type="submit" class="btn btn-danger">End Active Scheduled Maintenances</button>
+  </form>
 </div>
 <% if @states.empty? %>
   <div>

--- a/spec/lib/flapjack/gateways/web_spec.rb
+++ b/spec/lib/flapjack/gateways/web_spec.rb
@@ -279,6 +279,16 @@ describe Flapjack::Gateways::Web, :sinatra => true, :logger => true do
       expect(last_response.status).to eq(302)
     end
 
+    it "deletes a scheduled maintenance period for an entity" do
+      expect(Flapjack::Data::Entity).to receive(:find_by_name).
+        with(entity_name, :redis => redis).and_return(entity)
+
+      expect(entity).to receive(:end_scheduled_maintenance)#.with(start_time)
+
+      adelete "/scheduled_maintenances/#{entity_name_esc}"
+      expect(last_response.status).to eq(302)
+    end
+
     it "shows a list of all known contacts" do
       expect(Flapjack::Data::Contact).to receive(:all)
 


### PR DESCRIPTION
To take all checks out of scheduled maintenance for an entity, a button was added to the entity page. Only the active scheduled maintenance will be ended, any future scheduled maintenance will be kept.