### PR TITLE
Fixed check for toml configuration hash keys

### DIFF
--- a/lib/flapjack/utility.rb
+++ b/lib/flapjack/utility.rb
@@ -89,8 +89,7 @@ module Flapjack
 
     def load_template(template_config, message_type, message_filetype,
                       default_template_path)
-      template_file = if template_config.nil? ||
-          !template_config.has_key?("#{message_type}_#{message_filetype}")
+      template_file = if template_config.nil? || !template_config.has_key?("#{message_type}_#{message_filetype}")
         # we ship UTF-8 templates with the gem
         template_path = File.join(default_template_path, "#{message_type}.#{message_filetype}.erb")
         File.open(template_path, "r:UTF-8", &:read)

--- a/lib/flapjack/utility.rb
+++ b/lib/flapjack/utility.rb
@@ -89,13 +89,14 @@ module Flapjack
 
     def load_template(template_config, message_type, message_filetype,
                       default_template_path)
-      template_file = if template_config.nil? || !template_config.has_key?("#{message_type}.#{message_filetype}")
+      template_file = if template_config.nil? ||
+          !template_config.has_key?("#{message_type}_#{message_filetype}")
         # we ship UTF-8 templates with the gem
         template_path = File.join(default_template_path, "#{message_type}.#{message_filetype}.erb")
         File.open(template_path, "r:UTF-8", &:read)
       else
          # respects Encoding.default_external (UTF-8 or ENV['LANG'])
-        template_path = template_config["#{message_type}.#{message_filetype}"]
+        template_path = template_config["#{message_type}_#{message_filetype}"]
         File.read(template_path)
       end
       [ERB.new(template_file, nil, '-'), template_file]


### PR DESCRIPTION
the example toml file says the keys should be snake cased
the check within this method checks for dot_separated key strings

This fixes the following issue
custom email templates are ignored #933
